### PR TITLE
feat: o11y metrics endpoint

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -214,6 +214,13 @@ pub const time = struct {
     pub const ns_per_century: i64 = 100 * ns_per_year;
 };
 
+// Metrics Server
+pub const metrics = struct {
+    pub const enabled: bool = true;
+    pub const port: u16 = 7702;
+    pub const address: [4]u8 = .{ 127, 0, 0, 1 };
+};
+
 // Compile-Time Validation
 
 comptime {
@@ -251,6 +258,17 @@ comptime {
     // Time validation.
     assert(time.ns_per_sec == 1_000_000_000);
     assert(time.ns_per_day == 86_400_000_000_000);
+
+    // Metrics validation.
+    assert(metrics.port > 0);
+    assert(metrics.port < 65535);
+    assert(metrics.port != server.port);
+
+    // Bench validation.
+    assert(benchmark.default_iterations > 0);
+    assert(benchmark.ingest_point_count > 0);
+    assert(benchmark.query_count > 0);
+    assert(benchmark.auth_verify_count > 0);
 }
 
 // Tests
@@ -280,4 +298,22 @@ test "time constants are correct" {
     try std.testing.expectEqual(@as(i64, 1_000_000_000), time.ns_per_sec);
     try std.testing.expectEqual(@as(i64, 60_000_000_000), time.ns_per_min);
     try std.testing.expectEqual(@as(i64, 3_600_000_000_000), time.ns_per_hour);
+}
+
+test "storage config is valid" {
+    try std.testing.expect(storage.segment_capacity_default <= storage.segment_capacity_max);
+    try std.testing.expect(storage.label_length == 32);
+}
+
+test "benchmark config is valid" {
+    try std.testing.expect(benchmark.default_iterations > 0);
+    try std.testing.expect(benchmark.ingest_point_count > 0);
+    try std.testing.expect(benchmark.query_count > 0);
+    try std.testing.expect(benchmark.auth_verify_count > 0);
+}
+
+test "metrics config is valid" {
+    try std.testing.expect(metrics.enabled == true);
+    try std.testing.expect(metrics.port > 0);
+    try std.testing.expect(metrics.port < 65535);
 }

--- a/src/server/metrics_server.zig
+++ b/src/server/metrics_server.zig
@@ -1,0 +1,323 @@
+//! Prometheus-compatible metrics server.
+//!
+//! Runs a minimal HTTP responder on a separate port that serves
+//! GET /metrics in Prometheus text exposition format. No routing,
+//! no request parsing beyond detecting a complete HTTP request.
+
+const std = @import("std");
+const config = @import("tau").config;
+const catalog_mod = @import("catalog");
+
+const log = std.log.scoped(.metrics);
+
+pub const Counters = struct {
+    connections_active: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    connections_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    requests_connect: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_disconnect: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_ping: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_create_series: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_drop_series: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_append: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    requests_query_point: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    errors_bad_magic: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_bad_version: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_bad_opcode: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_payload_too_large: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_not_authenticated: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_auth_failed: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_series_not_found: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_series_already_exists: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_invalid_payload: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_internal_error: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors_out_of_order: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    start_time_ms: i64 = 0,
+
+    pub fn init() Counters {
+        return .{
+            .start_time_ms = std.time.milliTimestamp(),
+        };
+    }
+
+    pub fn inc_request(self: *Counters, opcode: @import("protocol").Opcode) void {
+        switch (opcode) {
+            .connect => _ = self.requests_connect.fetchAdd(1, .monotonic),
+            .disconnect => _ = self.requests_disconnect.fetchAdd(1, .monotonic),
+            .ping => _ = self.requests_ping.fetchAdd(1, .monotonic),
+            .create_series => _ = self.requests_create_series.fetchAdd(1, .monotonic),
+            .drop_series => _ = self.requests_drop_series.fetchAdd(1, .monotonic),
+            .append => _ = self.requests_append.fetchAdd(1, .monotonic),
+            .query_point => _ = self.requests_query_point.fetchAdd(1, .monotonic),
+            else => {},
+        }
+    }
+
+    pub fn inc_error(self: *Counters, status: @import("protocol").StatusCode) void {
+        switch (status) {
+            .bad_magic => _ = self.errors_bad_magic.fetchAdd(1, .monotonic),
+            .bad_version => _ = self.errors_bad_version.fetchAdd(1, .monotonic),
+            .bad_opcode => _ = self.errors_bad_opcode.fetchAdd(1, .monotonic),
+            .payload_too_large => _ = self.errors_payload_too_large.fetchAdd(1, .monotonic),
+            .not_authenticated => _ = self.errors_not_authenticated.fetchAdd(1, .monotonic),
+            .auth_failed => _ = self.errors_auth_failed.fetchAdd(1, .monotonic),
+            .series_not_found => _ = self.errors_series_not_found.fetchAdd(1, .monotonic),
+            .series_already_exists => _ = self.errors_series_already_exists.fetchAdd(1, .monotonic),
+            .invalid_payload => _ = self.errors_invalid_payload.fetchAdd(1, .monotonic),
+            .internal_error => _ = self.errors_internal_error.fetchAdd(1, .monotonic),
+            .out_of_order => _ = self.errors_out_of_order.fetchAdd(1, .monotonic),
+            .success => {},
+        }
+    }
+
+    pub fn connection_opened(self: *Counters) void {
+        _ = self.connections_active.fetchAdd(1, .monotonic);
+        _ = self.connections_total.fetchAdd(1, .monotonic);
+    }
+
+    pub fn connection_closed(self: *Counters) void {
+        _ = self.connections_active.fetchSub(1, .monotonic);
+    }
+};
+
+pub fn format_metrics(
+    counters: *Counters,
+    catalog: *catalog_mod.Catalog,
+    buf: []u8,
+) ![]const u8 {
+    var stream = std.io.fixedBufferStream(buf);
+    const w = stream.writer();
+
+    try w.writeAll("# HELP tau_connections_active Current open connections.\n");
+    try w.writeAll("# TYPE tau_connections_active gauge\n");
+    try std.fmt.format(w, "tau_connections_active {d}\n", .{
+        counters.connections_active.load(.monotonic),
+    });
+
+    try w.writeAll("# HELP tau_connections_total Total accepted connections.\n");
+    try w.writeAll("# TYPE tau_connections_total counter\n");
+    try std.fmt.format(w, "tau_connections_total {d}\n", .{
+        counters.connections_total.load(.monotonic),
+    });
+
+    try w.writeAll("# HELP tau_requests_total Total requests by opcode.\n");
+    try w.writeAll("# TYPE tau_requests_total counter\n");
+    const req_fields = .{
+        .{ "connect", &counters.requests_connect },
+        .{ "disconnect", &counters.requests_disconnect },
+        .{ "ping", &counters.requests_ping },
+        .{ "create_series", &counters.requests_create_series },
+        .{ "drop_series", &counters.requests_drop_series },
+        .{ "append", &counters.requests_append },
+        .{ "query_point", &counters.requests_query_point },
+    };
+    inline for (req_fields) |entry| {
+        try std.fmt.format(w, "tau_requests_total{{op=\"{s}\"}} {d}\n", .{
+            entry[0],
+            entry[1].load(.monotonic),
+        });
+    }
+
+    try w.writeAll("# HELP tau_errors_total Error responses by status code.\n");
+    try w.writeAll("# TYPE tau_errors_total counter\n");
+    const err_fields = .{
+        .{ "bad_magic", &counters.errors_bad_magic },
+        .{ "bad_version", &counters.errors_bad_version },
+        .{ "bad_opcode", &counters.errors_bad_opcode },
+        .{ "payload_too_large", &counters.errors_payload_too_large },
+        .{ "not_authenticated", &counters.errors_not_authenticated },
+        .{ "auth_failed", &counters.errors_auth_failed },
+        .{ "series_not_found", &counters.errors_series_not_found },
+        .{ "series_already_exists", &counters.errors_series_already_exists },
+        .{ "invalid_payload", &counters.errors_invalid_payload },
+        .{ "internal_error", &counters.errors_internal_error },
+        .{ "out_of_order", &counters.errors_out_of_order },
+    };
+    inline for (err_fields) |entry| {
+        try std.fmt.format(w, "tau_errors_total{{status=\"{s}\"}} {d}\n", .{
+            entry[0],
+            entry[1].load(.monotonic),
+        });
+    }
+
+    // Catalog metrics (read under existing RwLock).
+    catalog.lock.lockShared();
+    const series_count = catalog.series_map.count();
+    catalog.lock.unlockShared();
+
+    try w.writeAll("# HELP tau_series_count Number of live series.\n");
+    try w.writeAll("# TYPE tau_series_count gauge\n");
+    try std.fmt.format(w, "tau_series_count {d}\n", .{series_count});
+
+    // Process metrics.
+    const uptime_ms = std.time.milliTimestamp() - counters.start_time_ms;
+    const uptime_s: f64 = @as(f64, @floatFromInt(uptime_ms)) / 1000.0;
+
+    try w.writeAll("# HELP tau_uptime_seconds Time since server start.\n");
+    try w.writeAll("# TYPE tau_uptime_seconds gauge\n");
+    try std.fmt.format(w, "tau_uptime_seconds {d:.3}\n", .{uptime_s});
+
+    return stream.getWritten();
+}
+
+pub const MetricsServer = struct {
+    counters: *Counters,
+    catalog: *catalog_mod.Catalog,
+    server: ?std.net.Server,
+    thread: ?std.Thread,
+
+    const Self = @This();
+
+    pub fn init(
+        counters: *Counters,
+        catalog: *catalog_mod.Catalog,
+    ) Self {
+        return .{
+            .counters = counters,
+            .catalog = catalog,
+            .server = null,
+            .thread = null,
+        };
+    }
+
+    pub fn start(self: *Self) !void {
+        const address = std.net.Address.initIp4(
+            config.metrics.address,
+            config.metrics.port,
+        );
+
+        self.server = std.net.Address.listen(
+            address,
+            .{ .reuse_address = true },
+        ) catch |err| {
+            log.err("metrics bind failed: {s}", .{@errorName(err)});
+            return err;
+        };
+
+        self.thread = try std.Thread.spawn(.{}, accept_loop, .{self});
+
+        log.info("metrics listening on port {d}", .{config.metrics.port});
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (self.server) |*s| {
+            s.deinit();
+        }
+    }
+
+    fn accept_loop(self: *Self) void {
+        while (true) {
+            const connection = self.server.?.accept() catch |err| {
+                log.err("metrics accept failed: {s}", .{@errorName(err)});
+                continue;
+            };
+            self.handle_connection(connection.stream);
+        }
+    }
+
+    fn handle_connection(self: *Self, stream: std.net.Stream) void {
+        defer stream.close();
+
+        var req_buf: [1024]u8 = undefined;
+        var filled: usize = 0;
+        while (filled < req_buf.len) {
+            const n = stream.read(req_buf[filled..]) catch return;
+            if (n == 0) return;
+            filled += n;
+
+            if (std.mem.indexOf(u8, req_buf[0..filled], "\r\n\r\n") != null) break;
+        }
+
+        var body_buf: [16384]u8 = undefined;
+        const body = format_metrics(
+            self.counters,
+            self.catalog,
+            &body_buf,
+        ) catch {
+            const err_resp = "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n";
+            _ = stream.write(err_resp) catch {};
+            return;
+        };
+
+        var header_buf: [256]u8 = undefined;
+        const header = std.fmt.bufPrint(
+            &header_buf,
+            "HTTP/1.1 200 OK\r\n" ++
+                "Content-Type: text/plain; version=0.0.4\r\n" ++
+                "Content-Length: {d}\r\n" ++
+                "Connection: close\r\n" ++
+                "\r\n",
+            .{body.len},
+        ) catch return;
+
+        _ = stream.write(header) catch return;
+        _ = stream.write(body) catch return;
+    }
+};
+
+const testing = std.testing;
+
+test "Counters.init sets start time" {
+    const counters = Counters.init();
+    try testing.expect(counters.start_time_ms > 0);
+}
+
+test "Counters.inc_request increments correct counter" {
+    var counters = Counters.init();
+    counters.inc_request(.append);
+    counters.inc_request(.append);
+    counters.inc_request(.ping);
+
+    try testing.expectEqual(@as(u64, 2), counters.requests_append.load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), counters.requests_ping.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), counters.requests_connect.load(.monotonic));
+}
+
+test "Counters.inc_error increments correct counter" {
+    var counters = Counters.init();
+
+    counters.inc_error(.auth_failed);
+    counters.inc_error(.series_not_found);
+    counters.inc_error(.series_not_found);
+
+    try testing.expectEqual(@as(u64, 1), counters.errors_auth_failed.load(.monotonic));
+    try testing.expectEqual(@as(u64, 2), counters.errors_series_not_found.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), counters.errors_bad_magic.load(.monotonic));
+}
+
+test "Counters.connection_opened and connection_closed" {
+    var counters = Counters.init();
+
+    counters.connection_opened();
+    counters.connection_opened();
+    try testing.expectEqual(@as(u64, 2), counters.connections_active.load(.monotonic));
+    try testing.expectEqual(@as(u64, 2), counters.connections_total.load(.monotonic));
+
+    counters.connection_closed();
+    try testing.expectEqual(@as(u64, 1), counters.connections_active.load(.monotonic));
+    try testing.expectEqual(@as(u64, 2), counters.connections_total.load(.monotonic));
+}
+
+test "format_metrics produces valid Prometheus text" {
+    var counters = Counters.init();
+    var catalog = catalog_mod.Catalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    counters.inc_request(.append);
+    counters.inc_error(.auth_failed);
+    counters.connection_opened();
+
+    var buf: [16384]u8 = undefined;
+    const output = try format_metrics(&counters, &catalog, &buf);
+
+    try testing.expect(std.mem.indexOf(u8, output, "tau_connections_active 1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "tau_connections_total 1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "tau_requests_total{op=\"append\"} 1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "tau_errors_total{status=\"auth_failed\"} 1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "tau_series_count 0") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "tau_uptime_seconds") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "# TYPE tau_connections_active gauge") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "# TYPE tau_requests_total counter") != null);
+}

--- a/src/sim/main.zig
+++ b/src/sim/main.zig
@@ -8,6 +8,7 @@ const config = tau.config;
 
 const Harness = @import("harness.zig").Harness;
 const ScenarioConfig = @import("harness.zig").ScenarioConfig;
+const o11y = @import("scenarios/o11y.zig");
 
 const log = std.log.scoped(.sim);
 

--- a/src/sim/scenarios/o11y.zig
+++ b/src/sim/scenarios/o11y.zig
@@ -1,0 +1,273 @@
+//! Observability simulation scenario.
+//!
+//! Verifies that the metrics subsystem correctly tracks all
+//! server operations under deterministic simulated load.
+//! Exercises atomic counters, Prometheus text formatting,
+//! and invariant checking between counters and catalog state.
+
+const std = @import("std");
+const assert = std.debug.assert;
+
+const tau = @import("tau");
+const config = tau.config;
+
+const PRNG = @import("../prng.zig").PRNG;
+const Clock = @import("../clock.zig").Clock;
+const ns_per_day = @import("../clock.zig").ns_per_day;
+const FaultInjector = @import("../faults.zig").FaultInjector;
+const FaultConfig = @import("../faults.zig").FaultConfig;
+
+const catalog_mod = @import("catalog");
+const metrics_mod = @import("metrics");
+const protocol = @import("protocol");
+
+const log = std.log.scoped(.o11y);
+
+pub const O11yResult = struct {
+    seed: u64,
+    passed: bool,
+    simulated_days: u32,
+    total_requests: u64,
+    total_errors: u64,
+    total_connections: u64,
+    scrapes: u32,
+    invariant_violations: u32,
+    failure_reason: ?FailureReason,
+
+    pub const FailureReason = enum {
+        counter_mismatch,
+        format_error,
+        series_count_mismatch,
+        monotonicity_violated,
+    };
+};
+
+pub fn run(allocator: std.mem.Allocator, seed: u64, simulated_days: u32) O11yResult {
+    assert(seed >= 1);
+    assert(simulated_days > 0);
+    assert(simulated_days <= 365 * 10);
+
+    var prng = PRNG.init(seed);
+    var counters = metrics_mod.Counters.init();
+    var catalog = catalog_mod.Catalog.init(allocator);
+    defer catalog.deinit();
+
+    var expected_requests = std.mem.zeroes([std.meta.fields(protocol.Opcode).len]u64);
+    var expected_errors = std.mem.zeroes([std.meta.fields(protocol.StatusCode).len]u64);
+    var expected_connections_total: u64 = 0;
+    var expected_connections_active: u64 = 0;
+    var series_created: u32 = 0;
+    var violations: u32 = 0;
+    var scrapes: u32 = 0;
+
+    var day: u32 = 0;
+    while (day < simulated_days) : (day += 1) {
+        const ops_today = prng.range_u32(50) + 10;
+        var op: u32 = 0;
+        while (op < ops_today) : (op += 1) {
+            const roll = prng.range_u32(100);
+
+            if (roll < 10) {
+                counters.connection_opened();
+                expected_connections_total += 1;
+                expected_connections_active += 1;
+            } else if (roll < 15 and expected_connections_active > 0) {
+                counters.connection_closed();
+                expected_connections_active -= 1;
+            } else if (roll < 40) {
+                counters.inc_request(.append);
+                expected_requests[@intFromEnum(protocol.Opcode.append)] += 1;
+            } else if (roll < 55) {
+                counters.inc_request(.query_point);
+                expected_requests[@intFromEnum(protocol.Opcode.query_point)] += 1;
+            } else if (roll < 65) {
+                counters.inc_request(.ping);
+                expected_requests[@intFromEnum(protocol.Opcode.ping)] += 1;
+            } else if (roll < 75) {
+                counters.inc_request(.create_series);
+                expected_requests[@intFromEnum(protocol.Opcode.create_series)] += 1;
+
+                var label = [_]u8{0} ** catalog_mod.label_length;
+                const name = std.fmt.bufPrint(&label, "sim_{d}", .{series_created}) catch unreachable;
+                _ = name;
+                catalog.create_series(label) catch {};
+                series_created += 1;
+            } else if (roll < 80) {
+                counters.inc_error(.auth_failed);
+                expected_errors[@intFromEnum(protocol.StatusCode.auth_failed)] += 1;
+            } else if (roll < 85) {
+                counters.inc_error(.series_not_found);
+                expected_errors[@intFromEnum(protocol.StatusCode.series_not_found)] += 1;
+            } else if (roll < 90) {
+                counters.inc_error(.invalid_payload);
+                expected_errors[@intFromEnum(protocol.StatusCode.invalid_payload)] += 1;
+            } else if (roll < 95) {
+                counters.inc_request(.connect);
+                expected_requests[@intFromEnum(protocol.Opcode.connect)] += 1;
+            } else {
+                counters.inc_error(.bad_magic);
+                expected_errors[@intFromEnum(protocol.StatusCode.bad_magic)] += 1;
+            }
+        }
+
+        // Scrape metrics periodically (every 15 simulated days).
+        if (day % 15 == 0) {
+            var buf: [16384]u8 = undefined;
+            const output = metrics_mod.format_metrics(
+                &counters,
+                &catalog,
+                &buf,
+            ) catch {
+                return .{
+                    .seed = seed,
+                    .passed = false,
+                    .simulated_days = day,
+                    .total_requests = sum_array(&expected_requests),
+                    .total_errors = sum_array(&expected_errors),
+                    .total_connections = expected_connections_total,
+                    .scrapes = scrapes,
+                    .invariant_violations = violations,
+                    .failure_reason = .format_error,
+                };
+            };
+            scrapes += 1;
+
+            // Invariant: output contains required metric families.
+            if (std.mem.indexOf(u8, output, "tau_connections_active") == null or
+                std.mem.indexOf(u8, output, "tau_connections_total") == null or
+                std.mem.indexOf(u8, output, "tau_requests_total") == null or
+                std.mem.indexOf(u8, output, "tau_errors_total") == null or
+                std.mem.indexOf(u8, output, "tau_series_count") == null or
+                std.mem.indexOf(u8, output, "tau_uptime_seconds") == null)
+            {
+                violations += 1;
+            }
+        }
+    }
+
+    // Final invariant checks.
+
+    // 1. Connection counters.
+    if (counters.connections_total.load(.monotonic) != expected_connections_total) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+    if (counters.connections_active.load(.monotonic) != expected_connections_active) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+
+    // 2. Request counters.
+    if (counters.requests_append.load(.monotonic) != expected_requests[@intFromEnum(protocol.Opcode.append)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+    if (counters.requests_query_point.load(.monotonic) != expected_requests[@intFromEnum(protocol.Opcode.query_point)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+    if (counters.requests_ping.load(.monotonic) != expected_requests[@intFromEnum(protocol.Opcode.ping)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+    if (counters.requests_connect.load(.monotonic) != expected_requests[@intFromEnum(protocol.Opcode.connect)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+
+    // 3. Error counters.
+    if (counters.errors_auth_failed.load(.monotonic) != expected_errors[@intFromEnum(protocol.StatusCode.auth_failed)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+    if (counters.errors_series_not_found.load(.monotonic) != expected_errors[@intFromEnum(protocol.StatusCode.series_not_found)]) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .counter_mismatch);
+    }
+
+    // 4. Series count matches catalog.
+    catalog.lock.lockShared();
+    const catalog_count = catalog.series_map.count();
+    catalog.lock.unlockShared();
+
+    var buf: [16384]u8 = undefined;
+    const final_output = metrics_mod.format_metrics(&counters, &catalog, &buf) catch {
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations + 1, .format_error);
+    };
+
+    var expected_series_str: [64]u8 = undefined;
+    const needle = std.fmt.bufPrint(&expected_series_str, "tau_series_count {d}\n", .{catalog_count}) catch unreachable;
+    if (std.mem.indexOf(u8, final_output, needle) == null) {
+        violations += 1;
+        return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, .series_count_mismatch);
+    }
+
+    return result_from(seed, simulated_days, &expected_requests, &expected_errors, expected_connections_total, scrapes, violations, null);
+}
+
+fn sum_array(arr: []const u64) u64 {
+    var total: u64 = 0;
+    for (arr) |v| total += v;
+    return total;
+}
+
+fn result_from(
+    seed: u64,
+    simulated_days: u32,
+    expected_requests: []const u64,
+    expected_errors: []const u64,
+    expected_connections_total: u64,
+    scrapes: u32,
+    violations: u32,
+    failure_reason: ?O11yResult.FailureReason,
+) O11yResult {
+    return .{
+        .seed = seed,
+        .passed = violations == 0 and failure_reason == null,
+        .simulated_days = simulated_days,
+        .total_requests = sum_array(expected_requests),
+        .total_errors = sum_array(expected_errors),
+        .total_connections = expected_connections_total,
+        .scrapes = scrapes,
+        .invariant_violations = violations,
+        .failure_reason = failure_reason,
+    };
+}
+
+// Tests
+
+const testing = std.testing;
+
+test "o11y scenario passes with deterministic seed" {
+    const result = run(testing.allocator, 42, 30);
+    try testing.expect(result.passed);
+    try testing.expectEqual(@as(u32, 0), result.invariant_violations);
+    try testing.expect(result.total_requests > 0);
+    try testing.expect(result.total_connections > 0);
+    try testing.expect(result.scrapes > 0);
+}
+
+test "o11y scenario is deterministic" {
+    const result1 = run(testing.allocator, 12345, 60);
+    const result2 = run(testing.allocator, 12345, 60);
+
+    try testing.expectEqual(result1.passed, result2.passed);
+    try testing.expectEqual(result1.total_requests, result2.total_requests);
+    try testing.expectEqual(result1.total_errors, result2.total_errors);
+    try testing.expectEqual(result1.total_connections, result2.total_connections);
+    try testing.expectEqual(result1.invariant_violations, result2.invariant_violations);
+}
+
+test "o11y scenario passes with multiple seeds" {
+    const seeds = [_]u64{ 1, 99, 777, 54321, 999999 };
+    for (seeds) |seed| {
+        const result = run(testing.allocator, seed, 30);
+        try testing.expect(result.passed);
+    }
+}
+
+test "o11y scenario passes with long duration" {
+    const result = run(testing.allocator, 42, 365);
+    try testing.expect(result.passed);
+    try testing.expect(result.scrapes > 20);
+}


### PR DESCRIPTION
## What

Add a Prometheus-compatible metrics endpoint exposing server and storage internals.

## Why

No observability into the running server today. Prometheus exposition format is the standard for pull-based monitoring and works with Grafana, Alertmanager, etc. out of the box.

## Testing

Interact with server, verify served counts change as expected. 

Closes #5 