### PR TITLE
Testing dst and tidy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "dst"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "hegeltest",
@@ -713,7 +713,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdst"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "hegeltest",
  "hegeltest-macros",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "libtau"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "tau"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "hegeltest",

--- a/crates/dst/src/profile.rs
+++ b/crates/dst/src/profile.rs
@@ -83,6 +83,14 @@ impl ProfileSpec {
         bootstrap_oracle_model(self, paths)
     }
 
+    /// Reopen the disk-backed executor from its existing `.dat` files without
+    /// re-issuing DDL — models a process restart for the persistence checks.
+    #[cfg(test)]
+    pub fn reopen_disk_executor(&self, paths: &ProfilePaths) -> Executor {
+        let d = paths.disk_dir.as_ref().expect("disk dir");
+        reopen_disk(d, self.compact_threshold(), self.enc_key())
+    }
+
     /// Shared executor + ephemeral tau server for wire transport profiles.
     pub fn spawn_wire_stack(
         &self,
@@ -163,6 +171,21 @@ fn bootstrap_disk(dir: &Path, threshold: usize, enc_key: Option<[u8; 32]>) -> Ex
     exec(&mut ex, "CREATE DATABASE aux");
     exec(&mut ex, "USE DATABASE aux");
     exec(&mut ex, &format!("CREATE LENS {} int", Lens::Aux.as_str()));
+    exec(&mut ex, "USE DATABASE default");
+    ex
+}
+
+/// Reopen an existing disk-backed executor **without** re-issuing schema DDL —
+/// `CREATE DATABASE` replays each `.dat` file's persisted schema, so lenses and
+/// policies come back automatically. Models a real process restart (used by the
+/// disk-persistence DST coverage).
+#[cfg(test)]
+pub fn reopen_disk(dir: &Path, threshold: usize, enc_key: Option<[u8; 32]>) -> Executor {
+    let mut ex =
+        Executor::with_disk_backend(dir, threshold, libtau::storage::DEFAULT_ZSTD_LEVEL, enc_key)
+            .expect("disk backend reopen");
+    exec(&mut ex, "CREATE DATABASE default");
+    exec(&mut ex, "CREATE DATABASE aux");
     exec(&mut ex, "USE DATABASE default");
     ex
 }

--- a/crates/dst/src/sim.rs
+++ b/crates/dst/src/sim.rs
@@ -448,4 +448,145 @@ mod profile_tests {
         );
         assert_eq!(r.errors, 0, "disk no-checkpoint had {} errors", r.errors);
     }
+
+    /// Faithful disk restart (no wipe, no op-log replay to target): after writes
+    /// that each flushed (per-append durability), re-opening the executor over the
+    /// existing .dat files must see the same data and schema that the oracle has.
+    /// This exercises the disk backend's append_schema + append paths + executor's
+    /// CREATE DATABASE schema replay for a real process restart.
+    #[test]
+    fn pbt_disk_persists_data_and_schema_across_reopen() {
+        use crate::apply::apply_dual_executor;
+        use crate::harness;
+        use crate::op::Op;
+        use crate::oracle::DeriveSpec;
+        use crate::target::DirectExecutor;
+
+        let disk = ProfileSpec {
+            storage: Storage::Disk,
+            compaction: Compaction::Default,
+            encryption: Encryption::Plain,
+            transport: Transport::Direct,
+            auth: crate::profile::Auth::Off,
+        };
+        let workspace = crate::profile::ProfileWorkspace::new(disk);
+        let paths = &workspace.paths;
+
+        let mut target = disk.bootstrap_executor(paths);
+        let mut model = disk.bootstrap_oracle(paths);
+
+        // A small, varied sequence exercising DDL (extra lenses, derive, drop) + DML (appends)
+        // and probes. All go through dual-apply so target and model stay in sync.
+        // Use lenses from the DST bootstrap set ("a","b" are the int ones) plus the new "p".
+        // (No TTL here; TTL persistence is covered by dedicated unit regression tests using
+        // an ancient datum + small TTL window relative to the fixed DST wall clock.)
+        let ops: Vec<Op> = vec![
+            Op::CreateLens {
+                name: "p".into(),
+                ty: "int",
+            },
+            Op::Append {
+                lens: "p".into(),
+                data: crate::op::Payload::Int(vec![(0, 100, 1), (100, 200, 2)]),
+            },
+            Op::Derive {
+                name: "p2".into(),
+                spec: DeriveSpec {
+                    a: "p".into(),
+                    b: "a".into(),
+                },
+            },
+            Op::Append {
+                lens: "a".into(),
+                data: crate::op::Payload::Int(vec![(10, 50, 99)]),
+            },
+            Op::DropLens { name: "p2".into() }, // dropped derived should stay dropped after restart
+        ];
+
+        for (i, op) in ops.iter().enumerate() {
+            let divs = apply_dual_executor(i, op, &mut target, &mut model);
+            assert!(divs.is_empty(), "pre-restart divergence at {i}: {divs:?}");
+            // Right after the append that populates p, the data must be visible on target (before later DDL).
+            if i == 1 {
+                let imm = harness::exec(&mut target, "AT LENS p 50");
+                let v = match imm {
+                    libtau::Output::Value(v) => v,
+                    other => panic!("immediate post-append-p AT unexpected: {other:?}"),
+                };
+                assert_eq!(
+                    v,
+                    Some(libtau::Value::Int(1)),
+                    "target cannot see data immediately after its append to p (step {i})"
+                );
+            }
+            // After each later DDL/DML, re-probe p to see if a subsequent op made prior data invisible.
+            if i >= 2 {
+                let probe = harness::exec(&mut target, "AT LENS p 50");
+                let v = match probe {
+                    libtau::Output::Value(v) => v,
+                    other => panic!("AT p 50 after op {i} unexpected variant: {other:?}"),
+                };
+                assert_eq!(
+                    v,
+                    Some(libtau::Value::Int(1)),
+                    "p data disappeared from target after op {i} (derive/append/drop side effect?)"
+                );
+            }
+        }
+
+        // Sanity: the original target (pre-drop) must itself see the data we just appended.
+        // If this fails, the problem is in apply/append visibility, not restart persistence.
+        let pre_p = harness::exec(&mut target, "AT LENS p 50");
+        let pre_p_val = match pre_p {
+            libtau::Output::Value(v) => v,
+            other => panic!("pre-restart AT p 50 unexpected: {other:?}"),
+        };
+        assert_eq!(
+            pre_p_val,
+            Some(libtau::Value::Int(1)),
+            "original target cannot see its own append to p"
+        );
+
+        // Drop the target (ensuring last flush completed) and reopen from the on-disk files.
+        drop(target);
+        let mut restarted = disk.reopen_disk_executor(paths);
+        // Ensure tx flags are consistent (no tx in this sequence, but keep the helper honest).
+        crate::apply::sync_transactions(&mut DirectExecutor(&mut restarted), &mut model);
+
+        // Post-restart, the reopened target must match the oracle for data and names.
+        // (Schema for p, the appends to p and i0, the TTL on p, and absence of p2 were all
+        // persisted via append_schema/append + flush on each write.)
+        for (lens, t, expected) in [
+            ("p", 50, Some(libtau::Value::Int(1))),
+            ("p", 150, Some(libtau::Value::Int(2))),
+            ("a", 30, Some(libtau::Value::Int(99))),
+            ("a", 1000, None),
+        ] {
+            let out = harness::exec(&mut restarted, &format!("AT LENS {lens} {t}"));
+            let got = match out {
+                libtau::Output::Value(v) => v,
+                other => panic!("expected Value for AT, got {other:?}"),
+            };
+            assert_eq!(got, expected, "AT LENS {lens} {t} mismatch after reopen");
+        }
+
+        // p2 was dropped before restart; it must still be unknown (DROP persisted).
+        let (_, stmt) = libtau::parse("AT LENS p2 0").expect("parse p2 at");
+        let direct_res = restarted.exec(&stmt);
+        assert!(
+            direct_res.is_err(),
+            "p2 should remain dropped after reopen: {direct_res:?}"
+        );
+
+        // SHOW LENSES should not include the dropped p2 (but will include the base set + p).
+        if let libtau::Output::Names(names) = harness::exec(&mut restarted, "SHOW LENSES") {
+            assert!(
+                !names.iter().any(|n| n == "p2"),
+                "p2 must not appear after restart"
+            );
+            assert!(names.iter().any(|n| n == "p"), "p must survive restart");
+        } else {
+            panic!("SHOW LENSES did not return Names");
+        }
+    }
 }

--- a/crates/libtau/README.md
+++ b/crates/libtau/README.md
@@ -61,6 +61,6 @@ let result = exec.exec_read(&stmt).unwrap();
 | Flag / setter | Effect |
 |---------------|--------|
 | `Database::set_wal_fsync_each(false)` + `wal_flush()` | Group-commit mode: batch WAL flushes every 50 ms |
-| `Disk::set_rewrite_on_compact(false)` | Skip disk-file rewrite after compaction |
+| `Disk::set_compression_level(n)` | zstd level 1–22 for the disk backend (1 = fastest, 22 = best ratio) |
 | `Database::set_auto_checkpoint(false)` | Skip WAL checkpoint after compaction |
 | `Database::set_wal_max_bytes(n)` | Trigger a WAL checkpoint rewrite when the file exceeds `n` bytes, bounding on-disk WAL growth between compactions |

--- a/crates/libtau/src/README.md
+++ b/crates/libtau/src/README.md
@@ -6,13 +6,13 @@ The core engine library. All binaries depend only on this crate.
 
 | Module | Purpose |
 |--------|---------|
-| `model` | `Tau<V>`, `Layer<V>`, `Lens<V>` — the three data primitives |
+| `model` | `Tau<V>`, `Layer<V>` — the core temporal primitives (a "lens" is a named base/derived entry tracked by the executor, not a standalone type) |
 | `value` | `Value` enum (Int/Float/Str/Bool/Null) + tagged wire encoding |
 | `ql/ast` | TauQL AST (`Stmt`, `Expr`, `Literal`, `Type`, `BinOp` …) |
 | `ql/parser` | `nom`-based parser; entry point `parse()`, scalar helper `parse_literal()` |
 | `storage/store` | `Store<V>` trait; sweep-line compaction (`compact_layers`) |
 | `storage/memory` | `InMemory<V>` — `FxHashMap`-backed, zero I/O |
-| `storage/disk` | `Disk<V>` — binary flat file with AES-256-GCM encryption option |
+| `storage/disk` | `Disk<V>` — compressed binary file persisting layer data **and** schema DDL; optional AES-256-GCM encryption |
 | `storage/wal` | `Wal` — write-ahead log with schema DDL replay |
 | `database` | `Database<V>` — owns a `Store` + optional `Wal`; `Arc<Vec<Layer>>` snapshots |
 | `executor` | `Executor` — registry of named databases + dispatch + permissions |

--- a/crates/libtau/src/crypto.rs
+++ b/crates/libtau/src/crypto.rs
@@ -60,7 +60,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[hegel::test]
-    fn encrypt_decrypt_roundtrips(tc: TestCase) {
+    fn pbt_encrypt_decrypt_roundtrips(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let plaintext = tc.draw(gs::vecs(gs::integers::<u8>()).max_size(2048));
         let mut key = [0u8; 32];
@@ -71,7 +71,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn decrypt_rejects_too_short_blobs(tc: TestCase) {
+    fn pbt_decrypt_rejects_too_short_blobs(tc: TestCase) {
         let blob = tc.draw(gs::vecs(gs::integers::<u8>()).max_size(11));
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let key: [u8; 32] = key_bytes.try_into().expect("exactly 32 bytes");
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn decrypt_rejects_wrong_key(tc: TestCase) {
+    fn pbt_decrypt_rejects_wrong_key(tc: TestCase) {
         let plaintext = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(1).max_size(512));
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let key_a: [u8; 32] = key_bytes.try_into().expect("exactly 32 bytes");

--- a/crates/libtau/src/database.rs
+++ b/crates/libtau/src/database.rs
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn base_lookup_matches_layer_lookup(tc: TestCase) {
+    fn pbt_base_lookup_matches_layer_lookup(tc: TestCase) {
         let taus = tc.draw(taus_gen());
         let probe = tc.draw(gs::integers::<i64>().min_value(-5).max_value(500));
         let db = db();
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn newest_layer_wins_after_multiple_appends(tc: TestCase) {
+    fn pbt_newest_layer_wins_after_multiple_appends(tc: TestCase) {
         let taus_a = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let taus_b = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-5).max_value(500));
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn database_clone_shares_store(tc: TestCase) {
+    fn pbt_database_clone_shares_store(tc: TestCase) {
         let taus = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-5).max_value(500));
         let db1 = db();

--- a/crates/libtau/src/database.rs
+++ b/crates/libtau/src/database.rs
@@ -216,28 +216,37 @@ where
         }
     }
 
-    /// Write a schema DDL statement (e.g. `CREATE LENS temp int`) to the WAL.
-    ///
-    /// No-op when no WAL is configured.
+    /// Write a schema DDL statement (e.g. `CREATE LENS temp int`) to durable
+    /// storage.  Persisted in the WAL when one is attached, otherwise in the
+    /// store's own file (the disk backend).  No-op for a pure in-memory store.
     pub fn append_schema(&self, stmt_text: &str) -> io::Result<()> {
         if let Some(wal) = &self.wal {
             wal.lock()
                 .map_err(|_| io::Error::other("WAL mutex poisoned"))?
                 .append_schema(stmt_text)?;
+        } else {
+            self.store
+                .write()
+                .map_err(|_| io::Error::other("store lock poisoned"))?
+                .append_schema(stmt_text)?;
         }
         Ok(())
     }
 
-    /// Return the schema DDL statements stored in the WAL (in write order).
-    ///
-    /// Returns an empty vec when no WAL is configured.
+    /// Return the persisted schema DDL statements in write order, from the WAL
+    /// when attached, otherwise from the store's own file.  Empty for a pure
+    /// in-memory store.
     pub fn schema_stmts(&self) -> io::Result<Vec<String>> {
         match &self.wal {
             Some(wal) => wal
                 .lock()
                 .map_err(|_| io::Error::other("WAL mutex poisoned"))?
                 .replay_schemas(),
-            None => Ok(Vec::new()),
+            None => Ok(self
+                .store
+                .read()
+                .map_err(|_| io::Error::other("store lock poisoned"))?
+                .schema_stmts()),
         }
     }
 

--- a/crates/libtau/src/executor.rs
+++ b/crates/libtau/src/executor.rs
@@ -39,7 +39,8 @@ use crate::metrics::Op;
 use crate::model::{Layer, LayerId, Tau, Timestamp};
 use crate::ql::ast::{AggFunc, Expr, Stmt, Type};
 use crate::query::{
-    at_layers, build_range_segments, collect_range_bounds, eval_agg, eval_lens, would_cycle,
+    at_layers, build_range_segments, collect_range_bounds, eval_agg, eval_lens, ttl_cutoff,
+    would_cycle,
 };
 use crate::storage::{
     Disk, InMemory, sweep_range,
@@ -240,13 +241,6 @@ pub struct Executor {
     /// Instant the executor was created — used to report `uptime_secs` in
     /// `SHOW STATUS`.
     started_at: std::time::Instant,
-}
-
-fn ttl_cutoff(state: &DbState, lens: &str) -> Option<Timestamp> {
-    state
-        .ttl_secs
-        .get(lens)
-        .map(|&secs| crate::wall_clock::now_secs() - secs)
 }
 
 fn apply_offset_limit<T>(v: Vec<T>, offset: Option<usize>, limit: Option<usize>) -> Vec<T> {
@@ -1055,12 +1049,7 @@ impl Executor {
         if !state.base_types.contains_key(name) && !state.derived.contains_key(name) {
             return Err(ExecError::UnknownLens(name.into()));
         }
-        let cutoff = ttl_cutoff(&state, name);
-        let effective_start = if let Some(c) = cutoff {
-            start.max(c)
-        } else {
-            start
-        };
+        let effective_start = ttl_cutoff(&state, name).map_or(start, |c| start.max(c));
         if effective_start >= end {
             return Ok(Output::Range(vec![]));
         }
@@ -1105,12 +1094,7 @@ impl Executor {
         if !state.base_types.contains_key(name) && !state.derived.contains_key(name) {
             return Err(ExecError::UnknownLens(name.into()));
         }
-        let cutoff = ttl_cutoff(&state, name);
-        let effective_start = if let Some(c) = cutoff {
-            start.max(c)
-        } else {
-            start
-        };
+        let effective_start = ttl_cutoff(&state, name).map_or(start, |c| start.max(c));
         if effective_start >= end {
             return Ok(Output::Value(None));
         }

--- a/crates/libtau/src/executor.rs
+++ b/crates/libtau/src/executor.rs
@@ -131,8 +131,9 @@ pub enum StorageBackend {
     /// lost on clean shutdown without a WAL.
     Memory,
     /// Every database gets its own `<dir>/<name>.dat` compressed disk file.
-    /// Schema DDL (CREATE LENS / DERIVE LENS) is not persisted across restarts
-    /// in this release — re-issue DDL after startup.
+    /// Both layer data and schema DDL (CREATE LENS / DERIVE LENS / SET TTL) are
+    /// persisted; `CREATE DATABASE <name>` re-opens an existing file and replays
+    /// its schema, so lenses survive a restart.
     Disk {
         dir: std::path::PathBuf,
         compression_level: i32,
@@ -167,12 +168,14 @@ impl DbState {
         }
     }
 
+    /// Open (or create) a disk-backed database, returning the fresh state plus
+    /// any schema DDL persisted in the file so the executor can replay it.
     fn with_disk(
         path: impl AsRef<Path>,
         compact_threshold: usize,
         compression_level: i32,
         enc_key: Option<[u8; 32]>,
-    ) -> io::Result<Self> {
+    ) -> io::Result<(Self, Vec<String>)> {
         let path = path.as_ref();
         let mut store = if path.exists() {
             Disk::open(path, enc_key)?
@@ -183,13 +186,17 @@ impl DbState {
         store.set_compression_level(compression_level);
         let db = Database::new(store);
         let next_layer_id = db.max_layer_id() + 1;
-        Ok(Self {
-            db,
-            base_types: HashMap::default(),
-            next_layer_id,
-            derived: HashMap::default(),
-            ttl_secs: HashMap::default(),
-        })
+        let schema_stmts = db.schema_stmts().map_err(io::Error::other)?;
+        Ok((
+            Self {
+                db,
+                base_types: HashMap::default(),
+                next_layer_id,
+                derived: HashMap::default(),
+                ttl_secs: HashMap::default(),
+            },
+            schema_stmts,
+        ))
     }
 
     fn with_wal(
@@ -352,40 +359,15 @@ impl Executor {
         compact_threshold: usize,
         key: Option<[u8; 32]>,
     ) -> io::Result<Self> {
-        use crate::ql::parser::parse;
-
         let mut executor = Self::with_threshold(compact_threshold);
         let (db_state, schema_stmts) = DbState::with_wal(path, compact_threshold, key)?;
         executor
             .databases
             .insert("default".to_string(), Arc::new(RwLock::new(db_state)));
+        // Replay schema DDL (CREATE LENS / DERIVE LENS / SET TTL); in_replay
+        // suppresses writing these back to the WAL.
+        executor.replay_schema_stmts("default", &schema_stmts);
         executor.active = Some("default".to_string());
-
-        // Replay schema DDL (CREATE LENS / DERIVE LENS).
-        // in_replay suppresses writing these back to the WAL.
-        executor.in_replay = true;
-        for stmt_text in schema_stmts {
-            match parse(&stmt_text) {
-                Ok((_, stmt)) => {
-                    if let Err(e) = executor.exec(&stmt) {
-                        tracing::warn!(
-                            stmt = %stmt_text,
-                            error = ?e,
-                            "schema WAL replay: statement failed, skipping"
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        stmt = %stmt_text,
-                        error = %e,
-                        "schema WAL replay: parse error, skipping"
-                    );
-                }
-            }
-        }
-        executor.in_replay = false;
-
         Ok(executor)
     }
 
@@ -813,8 +795,8 @@ impl Executor {
             return Err(ExecError::DuplicateDatabase(name.into()));
         }
         let metrics = self.metrics.clone();
-        let mut db_state = match &self.backend {
-            StorageBackend::Memory => DbState::new(self.compact_threshold),
+        let (mut db_state, schema_stmts) = match &self.backend {
+            StorageBackend::Memory => (DbState::new(self.compact_threshold), Vec::new()),
             StorageBackend::Disk {
                 dir,
                 compression_level,
@@ -828,10 +810,38 @@ impl Executor {
         db_state.db.set_metrics(metrics);
         self.databases
             .insert(name.into(), Arc::new(RwLock::new(db_state)));
+        // Rebuild lens schema (CREATE/DERIVE/SET TTL) for a re-opened disk file.
+        self.replay_schema_stmts(name, &schema_stmts);
         if self.active.is_none() {
             self.active = Some(name.into());
         }
         Ok(Output::Empty)
+    }
+
+    /// Re-execute persisted schema DDL against `db_name` with WAL/disk writes
+    /// suppressed (`in_replay`), restoring the previously active database
+    /// afterwards.  Shared by the WAL-open, disk-open, and RESTORE paths.
+    fn replay_schema_stmts(&mut self, db_name: &str, stmts: &[String]) {
+        if stmts.is_empty() {
+            return;
+        }
+        let prev_active = self.active.take();
+        self.active = Some(db_name.to_string());
+        self.in_replay = true;
+        for stmt_text in stmts {
+            match crate::ql::parser::parse(stmt_text) {
+                Ok((_, stmt)) => {
+                    if let Err(e) = self.exec(&stmt) {
+                        tracing::warn!(stmt = %stmt_text, error = ?e, "schema replay: statement failed, skipping");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(stmt = %stmt_text, error = %e, "schema replay: parse error, skipping");
+                }
+            }
+        }
+        self.in_replay = false;
+        self.active = prev_active;
     }
 
     fn drop_database(&mut self, name: &str) -> Result<Output, ExecError> {
@@ -1385,23 +1395,7 @@ impl Executor {
             })),
         );
 
-        let prev_active = self.active.clone();
-        self.active = Some(name.into());
-        self.in_replay = true;
-        for stmt_text in &schema_stmts {
-            match crate::ql::parser::parse(stmt_text) {
-                Ok((_, stmt)) => {
-                    if let Err(e) = self.exec(&stmt) {
-                        tracing::warn!(stmt = %stmt_text, error = ?e, "restore: schema replay failed");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(stmt = %stmt_text, error = %e, "restore: schema parse error");
-                }
-            }
-        }
-        self.in_replay = false;
-        self.active = prev_active;
+        self.replay_schema_stmts(name, &schema_stmts);
         Ok(Output::Empty)
     }
 

--- a/crates/libtau/src/executor_tests.rs
+++ b/crates/libtau/src/executor_tests.rs
@@ -1616,3 +1616,92 @@ fn show_status_wire_roundtrip() {
     let parsed = Response::parse(&line).unwrap();
     assert_eq!(parsed, r);
 }
+
+/// Disk backend: schema DDL (CREATE/DERIVE) and layer data survive a restart.
+/// The "restart" drops the executor and opens a fresh one over the same dir.
+/// Nine appends force a compaction, which is the disk backend's flush trigger.
+#[test]
+fn disk_backend_persists_schema_and_data_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let threshold = crate::storage::COMPACT_THRESHOLD;
+    {
+        let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+        run(&mut e, "CREATE DATABASE main").unwrap();
+        run(&mut e, "CREATE LENS temp int").unwrap();
+        run(&mut e, "DERIVE LENS hot AS temp > 20").unwrap();
+        for i in 0..=(threshold as i64) {
+            run(
+                &mut e,
+                &format!(
+                    "APPEND LENS temp {} {} {}",
+                    i * 1000,
+                    i * 1000 + 1000,
+                    i * 10
+                ),
+            )
+            .unwrap();
+        }
+    }
+    // Fresh executor over the same directory; re-opening replays the schema.
+    let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+    run(&mut e, "CREATE DATABASE main").unwrap();
+
+    // Base + derived lenses are queryable with no re-issued DDL.
+    assert_eq!(
+        run(&mut e, "AT LENS temp 500").unwrap(),
+        Output::Value(Some(Value::Int(0)))
+    );
+    assert_eq!(
+        run(&mut e, "AT LENS hot 8500").unwrap(),
+        Output::Value(Some(Value::Bool(true)))
+    );
+    let Output::Names(lenses) = run(&mut e, "SHOW LENSES").unwrap() else {
+        panic!("expected names");
+    };
+    assert_eq!(lenses, vec!["hot".to_string(), "temp".to_string()]);
+}
+
+/// Disk backend: a persisted `SET TTL` policy is replayed on restart, so data
+/// older than the TTL window stays hidden without re-issuing the policy.
+#[test]
+fn disk_backend_persists_ttl_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let threshold = crate::storage::COMPACT_THRESHOLD;
+    {
+        let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+        run(&mut e, "CREATE DATABASE main").unwrap();
+        run(&mut e, "CREATE LENS old int").unwrap();
+        run(&mut e, "SET TTL LENS old 10").unwrap();
+        // Data far in the past (relative to wall clock); compaction forces a flush.
+        for i in 0..=(threshold as i64) {
+            run(
+                &mut e,
+                &format!("APPEND LENS old {} {} {}", i * 1000, i * 1000 + 1000, i),
+            )
+            .unwrap();
+        }
+    }
+    let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+    run(&mut e, "CREATE DATABASE main").unwrap();
+    // With the TTL replayed, the ancient datum is hidden (would be Some(0) otherwise).
+    assert_eq!(run(&mut e, "AT LENS old 500").unwrap(), Output::Value(None));
+}
+
+/// Disk backend: a `DROP LENS` persisted before restart stays dropped.
+#[test]
+fn disk_backend_drop_lens_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let threshold = crate::storage::COMPACT_THRESHOLD;
+    {
+        let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+        run(&mut e, "CREATE DATABASE main").unwrap();
+        run(&mut e, "CREATE LENS gone int").unwrap();
+        run(&mut e, "DROP LENS gone").unwrap();
+    }
+    let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
+    run(&mut e, "CREATE DATABASE main").unwrap();
+    assert!(matches!(
+        run(&mut e, "AT LENS gone 0"),
+        Err(ExecError::UnknownLens(_))
+    ));
+}

--- a/crates/libtau/src/executor_tests.rs
+++ b/crates/libtau/src/executor_tests.rs
@@ -897,7 +897,7 @@ fn appends_within_transaction_not_visible_before_commit() {
 }
 
 #[hegel::test]
-fn committed_transaction_matches_direct_writes(tc: TestCase) {
+fn pbt_committed_transaction_matches_direct_writes(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(6));
     let mut segs: Vec<(i64, i64, i64)> = Vec::new();
     let mut cursor: i64 = 0;
@@ -936,7 +936,7 @@ fn committed_transaction_matches_direct_writes(tc: TestCase) {
 }
 
 #[hegel::test]
-fn rollback_leaves_lens_unchanged(tc: TestCase) {
+fn pbt_rollback_leaves_lens_unchanged(tc: TestCase) {
     let base_val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
     let tx_val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
 
@@ -961,7 +961,7 @@ fn rollback_leaves_lens_unchanged(tc: TestCase) {
 }
 
 #[hegel::test]
-fn pending_writes_invisible_before_commit(tc: TestCase) {
+fn pbt_pending_writes_invisible_before_commit(tc: TestCase) {
     let val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
     let s = tc.draw(gs::integers::<i64>().min_value(1).max_value(1_000));
     let e_ts = s + tc.draw(gs::integers::<i64>().min_value(1).max_value(1_000));
@@ -980,7 +980,7 @@ fn pending_writes_invisible_before_commit(tc: TestCase) {
 }
 
 #[hegel::test]
-fn multiple_sequential_transactions_accumulate(tc: TestCase) {
+fn pbt_multiple_sequential_transactions_accumulate(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(5));
     let vals: Vec<i64> = (0..n)
         .map(|_| tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000)))
@@ -1006,7 +1006,7 @@ fn multiple_sequential_transactions_accumulate(tc: TestCase) {
 }
 
 #[hegel::test]
-fn rollback_then_commit_independent(tc: TestCase) {
+fn pbt_rollback_then_commit_independent(tc: TestCase) {
     let discard_val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
     let keep_val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
 
@@ -1074,7 +1074,7 @@ fn batch_append_empty_block_succeeds() {
 }
 
 #[hegel::test]
-fn batch_append_matches_regular_append(tc: TestCase) {
+fn pbt_batch_append_matches_regular_append(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(6));
     let mut segs: Vec<(i64, i64, i64)> = Vec::new();
     let mut cursor: i64 = 0;
@@ -1162,7 +1162,7 @@ fn history_lens_time_filter_excludes_non_overlapping_layers() {
 }
 
 #[hegel::test]
-fn history_lens_layer_count_matches_appends(tc: TestCase) {
+fn pbt_history_lens_layer_count_matches_appends(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(8));
     let mut e = setup();
     run(&mut e, "CREATE LENS x int").unwrap();
@@ -1265,7 +1265,7 @@ fn backup_restore_roundtrip_preserves_data() {
 }
 
 #[hegel::test]
-fn at_as_of_with_large_timestamp_matches_at(tc: TestCase) {
+fn pbt_at_as_of_with_large_timestamp_matches_at(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(6));
     let mut segs: Vec<(i64, i64, i64)> = Vec::new();
     let mut cursor: i64 = 0;
@@ -1296,7 +1296,7 @@ fn at_as_of_with_large_timestamp_matches_at(tc: TestCase) {
 }
 
 #[hegel::test]
-fn at_layer_for_single_layer_matches_at(tc: TestCase) {
+fn pbt_at_layer_for_single_layer_matches_at(tc: TestCase) {
     let s = tc.draw(gs::integers::<i64>().min_value(0).max_value(1_000));
     let len = tc.draw(gs::integers::<i64>().min_value(1).max_value(1_000));
     let val = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
@@ -1323,7 +1323,7 @@ fn at_layer_for_single_layer_matches_at(tc: TestCase) {
 }
 
 #[hegel::test]
-fn backup_restore_at_matches_original(tc: TestCase) {
+fn pbt_backup_restore_at_matches_original(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(1).max_value(6));
     let mut segs: Vec<(i64, i64, i64)> = Vec::new();
     let mut cursor: i64 = 0;
@@ -1432,7 +1432,7 @@ fn reduce_min_max_on_derived_lens() {
 }
 
 #[hegel::test]
-fn range_limit_truncates_segments(tc: TestCase) {
+fn pbt_range_limit_truncates_segments(tc: TestCase) {
     let n = tc.draw(gs::integers::<usize>().min_value(2).max_value(10));
     let limit = tc.draw(gs::integers::<usize>().min_value(1).max_value(n - 1));
     let mut e = Executor::new();

--- a/crates/libtau/src/executor_tests.rs
+++ b/crates/libtau/src/executor_tests.rs
@@ -1619,7 +1619,8 @@ fn show_status_wire_roundtrip() {
 
 /// Disk backend: schema DDL (CREATE/DERIVE) and layer data survive a restart.
 /// The "restart" drops the executor and opens a fresh one over the same dir.
-/// Nine appends force a compaction, which is the disk backend's flush trigger.
+/// A single append (no compaction) must persist — the backend flushes on every
+/// write — so one tau is queryable afterwards with no re-issued DDL.
 #[test]
 fn disk_backend_persists_schema_and_data_across_restart() {
     let dir = tempfile::tempdir().unwrap();
@@ -1629,18 +1630,7 @@ fn disk_backend_persists_schema_and_data_across_restart() {
         run(&mut e, "CREATE DATABASE main").unwrap();
         run(&mut e, "CREATE LENS temp int").unwrap();
         run(&mut e, "DERIVE LENS hot AS temp > 20").unwrap();
-        for i in 0..=(threshold as i64) {
-            run(
-                &mut e,
-                &format!(
-                    "APPEND LENS temp {} {} {}",
-                    i * 1000,
-                    i * 1000 + 1000,
-                    i * 10
-                ),
-            )
-            .unwrap();
-        }
+        run(&mut e, "APPEND LENS temp 0 1000 42").unwrap();
     }
     // Fresh executor over the same directory; re-opening replays the schema.
     let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
@@ -1649,10 +1639,10 @@ fn disk_backend_persists_schema_and_data_across_restart() {
     // Base + derived lenses are queryable with no re-issued DDL.
     assert_eq!(
         run(&mut e, "AT LENS temp 500").unwrap(),
-        Output::Value(Some(Value::Int(0)))
+        Output::Value(Some(Value::Int(42)))
     );
     assert_eq!(
-        run(&mut e, "AT LENS hot 8500").unwrap(),
+        run(&mut e, "AT LENS hot 500").unwrap(),
         Output::Value(Some(Value::Bool(true)))
     );
     let Output::Names(lenses) = run(&mut e, "SHOW LENSES").unwrap() else {
@@ -1672,18 +1662,12 @@ fn disk_backend_persists_ttl_across_restart() {
         run(&mut e, "CREATE DATABASE main").unwrap();
         run(&mut e, "CREATE LENS old int").unwrap();
         run(&mut e, "SET TTL LENS old 10").unwrap();
-        // Data far in the past (relative to wall clock); compaction forces a flush.
-        for i in 0..=(threshold as i64) {
-            run(
-                &mut e,
-                &format!("APPEND LENS old {} {} {}", i * 1000, i * 1000 + 1000, i),
-            )
-            .unwrap();
-        }
+        // Data far in the past relative to the wall clock; persisted immediately.
+        run(&mut e, "APPEND LENS old 0 1000 7").unwrap();
     }
     let mut e = Executor::with_disk_backend(dir.path(), threshold, 3, None).unwrap();
     run(&mut e, "CREATE DATABASE main").unwrap();
-    // With the TTL replayed, the ancient datum is hidden (would be Some(0) otherwise).
+    // With the TTL replayed, the ancient datum is hidden (would be Some(7) otherwise).
     assert_eq!(run(&mut e, "AT LENS old 500").unwrap(), Output::Value(None));
 }
 

--- a/crates/libtau/src/metrics.rs
+++ b/crates/libtau/src/metrics.rs
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn record_op_increments_count_and_ns(tc: TestCase) {
+    fn pbt_record_op_increments_count_and_ns(tc: TestCase) {
         let samples = tc
             .draw(gs::vecs(gs::integers::<u64>().min_value(0).max_value(10_000_000)).max_size(16));
         let m = Metrics::new();
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn prometheus_text_exposes_every_documented_family(tc: TestCase) {
+    fn pbt_prometheus_text_exposes_every_documented_family(tc: TestCase) {
         let _ = tc;
         let m = Metrics::new();
         m.record_op(Op::Append, 100);
@@ -507,7 +507,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn prometheus_text_count_matches_counters(tc: TestCase) {
+    fn pbt_prometheus_text_count_matches_counters(tc: TestCase) {
         let n = tc.draw(gs::integers::<u64>().min_value(0).max_value(20));
         let m = Metrics::new();
         for _ in 0..n {

--- a/crates/libtau/src/metrics.rs
+++ b/crates/libtau/src/metrics.rs
@@ -126,15 +126,6 @@ pub struct Metrics {
     proc_uptime: Gauge,
 }
 
-macro_rules! op_method {
-    ($fn:ident, $op:ident) => {
-        #[inline]
-        pub fn $fn(&self, ns: u64) {
-            self.record_op(Op::$op, ns);
-        }
-    };
-}
-
 impl Default for Metrics {
     fn default() -> Self {
         Self::new()
@@ -300,13 +291,6 @@ impl Metrics {
     pub fn record_op(&self, op: Op, ns: u64) {
         self.ops[op as usize].record(ns);
     }
-
-    op_method!(record_append, Append);
-    op_method!(record_at, At);
-    op_method!(record_range, Range);
-    op_method!(record_reduce, Reduce);
-    op_method!(record_history, History);
-    op_method!(record_ddl, Database);
 
     #[inline]
     pub fn record_compaction(&self) {

--- a/crates/libtau/src/model.rs
+++ b/crates/libtau/src/model.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn tau_new_preserves_fields_for_any_valid_range(tc: TestCase) {
+    fn pbt_tau_new_preserves_fields_for_any_valid_range(tc: TestCase) {
         let t = tc.draw(tau_gen());
         assert!(t.start < t.end);
         assert!(t.contains(t.start));
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn tau_contains_iff_in_half_open_range(tc: TestCase) {
+    fn pbt_tau_contains_iff_in_half_open_range(tc: TestCase) {
         let t = tc.draw(tau_gen());
         let probe = tc.draw(gs::integers::<i64>());
         let expected = t.start <= probe && probe < t.end;
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn layer_new_sorts_taus(tc: TestCase) {
+    fn pbt_layer_new_sorts_taus(tc: TestCase) {
         let taus = tc.draw(non_overlapping_taus());
         // Even after deliberate shuffling via a sort permutation, Layer::new
         // re-establishes start-order.
@@ -200,7 +200,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn layer_bounds_match_first_and_last(tc: TestCase) {
+    fn pbt_layer_bounds_match_first_and_last(tc: TestCase) {
         let taus = tc.draw(non_overlapping_taus().filter(|v| !v.is_empty()));
         let layer = Layer::new(1, taus);
         assert_eq!(layer.min_start, layer.taus.first().unwrap().start);
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn layer_empty_has_sentinel_bounds(tc: TestCase) {
+    fn pbt_layer_empty_has_sentinel_bounds(tc: TestCase) {
         let _ = tc;
         let layer: Layer<i32> = Layer::new(1, vec![]);
         assert_eq!(layer.min_start, Timestamp::MAX);
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn layer_at_matches_linear_scan(tc: TestCase) {
+    fn pbt_layer_at_matches_linear_scan(tc: TestCase) {
         let taus = tc.draw(non_overlapping_taus());
         let probe = tc.draw(gs::integers::<i64>().min_value(-10_000).max_value(10_000));
         let layer = Layer::new(1, taus.clone());

--- a/crates/libtau/src/ql/ast.rs
+++ b/crates/libtau/src/ql/ast.rs
@@ -465,7 +465,7 @@ mod tests {
     // CREATE LENS + DERIVE LENS are the two statements that round-trip through
     // Display (they're persisted in the schema WAL and replayed on startup).
     #[hegel::test]
-    fn create_lens_display_roundtrips(tc: TestCase) {
+    fn pbt_create_lens_display_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let ty = tc.draw(gs::sampled_from(vec![
             Type::Int,
@@ -484,7 +484,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn derive_lens_display_roundtrips(tc: TestCase) {
+    fn pbt_derive_lens_display_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let src = tc.draw(ident_gen());
         let stmt = Stmt::Derive {

--- a/crates/libtau/src/ql/parser.rs
+++ b/crates/libtau/src/ql/parser.rs
@@ -710,12 +710,9 @@ fn stmt_history(i: &str) -> IResult<&str, Stmt> {
     let (i, _) = kw("HISTORY").parse(i)?;
     let (i, _) = kw("LENS").parse(i)?;
     let (i, name) = ident(i)?;
-    let (i, range) = opt(map(
-        pair(
-            preceded(multispace1, integer),
-            preceded(multispace1, integer),
-        ),
-        |(start, end)| (start, end),
+    let (i, range) = opt(pair(
+        preceded(multispace1, integer),
+        preceded(multispace1, integer),
     ))
     .parse(i)?;
     Ok((i, Stmt::HistoryLens { name, range }))

--- a/crates/libtau/src/ql/parser.rs
+++ b/crates/libtau/src/ql/parser.rs
@@ -784,7 +784,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_never_panics_on_arbitrary_input(tc: TestCase) {
+    fn pbt_parse_never_panics_on_arbitrary_input(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(256));
         // The parser must return an `IResult` for every possible input - no
         // panics, no infinite loops, no allocation explosions.
@@ -792,7 +792,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn create_database_roundtrips(tc: TestCase) {
+    fn pbt_create_database_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         assert_eq!(
             parsed(&format!("CREATE DATABASE {name}")),
@@ -801,7 +801,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn drop_database_roundtrips(tc: TestCase) {
+    fn pbt_drop_database_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         assert_eq!(
             parsed(&format!("DROP DATABASE {name}")),
@@ -810,7 +810,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn use_database_roundtrips(tc: TestCase) {
+    fn pbt_use_database_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         assert_eq!(
             parsed(&format!("USE DATABASE {name}")),
@@ -819,7 +819,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn create_lens_roundtrips_for_every_type(tc: TestCase) {
+    fn pbt_create_lens_roundtrips_for_every_type(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let (kw, ty) = tc.draw(type_keyword_gen());
         assert_eq!(
@@ -829,20 +829,20 @@ mod tests {
     }
 
     #[hegel::test]
-    fn drop_lens_roundtrips(tc: TestCase) {
+    fn pbt_drop_lens_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         assert_eq!(parsed(&format!("DROP LENS {name}")), Stmt::Drop { name });
     }
 
     #[hegel::test]
-    fn at_lens_roundtrips_with_any_timestamp(tc: TestCase) {
+    fn pbt_at_lens_roundtrips_with_any_timestamp(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let t = tc.draw(gs::integers::<i64>());
         assert_eq!(parsed(&format!("AT LENS {name} {t}")), Stmt::At { name, t });
     }
 
     #[hegel::test]
-    fn range_lens_roundtrips_without_filter(tc: TestCase) {
+    fn pbt_range_lens_roundtrips_without_filter(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let start = tc.draw(
             gs::integers::<i64>()
@@ -868,7 +868,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn reduce_roundtrips_for_every_func(tc: TestCase) {
+    fn pbt_reduce_roundtrips_for_every_func(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let start = tc.draw(
             gs::integers::<i64>()
@@ -893,7 +893,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn append_lens_int_roundtrips(tc: TestCase) {
+    fn pbt_append_lens_int_roundtrips(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let s = tc.draw(
             gs::integers::<i64>()
@@ -916,7 +916,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn append_lens_bool_and_null_roundtrip(tc: TestCase) {
+    fn pbt_append_lens_bool_and_null_roundtrip(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let b = tc.draw(gs::booleans());
         let null_or_bool = tc.draw(gs::booleans());
@@ -935,7 +935,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn keywords_are_case_insensitive(tc: TestCase) {
+    fn pbt_keywords_are_case_insensitive(tc: TestCase) {
         let name = tc.draw(ident_gen());
         let upper = format!("CREATE LENS {name} int");
         let lower = upper.to_lowercase();
@@ -945,7 +945,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn extra_whitespace_is_tolerated(tc: TestCase) {
+    fn pbt_extra_whitespace_is_tolerated(tc: TestCase) {
         let pad_a = " ".repeat(tc.draw(gs::integers::<usize>().min_value(0).max_value(8)));
         let pad_b = " ".repeat(tc.draw(gs::integers::<usize>().min_value(1).max_value(8)));
         let pad_c = " ".repeat(tc.draw(gs::integers::<usize>().min_value(1).max_value(8)));
@@ -961,7 +961,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_rejects_unknown_leading_token(tc: TestCase) {
+    fn pbt_parse_rejects_unknown_leading_token(tc: TestCase) {
         let junk = tc.draw(gs::from_regex("[A-Z]{3,8}").fullmatch(true).filter(|s| {
             !matches!(
                 s.as_str(),

--- a/crates/libtau/src/query.rs
+++ b/crates/libtau/src/query.rs
@@ -51,7 +51,7 @@ pub(crate) fn would_cycle(
     false
 }
 
-fn ttl_cutoff(state: &DbState, lens: &str) -> Option<Timestamp> {
+pub(crate) fn ttl_cutoff(state: &DbState, lens: &str) -> Option<Timestamp> {
     state
         .ttl_secs
         .get(lens)

--- a/crates/libtau/src/query.rs
+++ b/crates/libtau/src/query.rs
@@ -587,7 +587,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_unary_neg_int_negates(tc: TestCase) {
+    fn pbt_apply_unary_neg_int_negates(tc: TestCase) {
         let v = tc.draw(gs::integers::<i64>());
         assert_eq!(
             apply_unary(UnOp::Neg, Value::Int(v)).unwrap(),
@@ -596,7 +596,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_unary_neg_float_negates(tc: TestCase) {
+    fn pbt_apply_unary_neg_float_negates(tc: TestCase) {
         let v = tc.draw(gs::floats::<f64>().filter(|f| f.is_finite()));
         assert_eq!(
             apply_unary(UnOp::Neg, Value::Float(v)).unwrap(),
@@ -605,7 +605,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_unary_not_inverts_bool(tc: TestCase) {
+    fn pbt_apply_unary_not_inverts_bool(tc: TestCase) {
         let b = tc.draw(gs::booleans());
         assert_eq!(
             apply_unary(UnOp::Not, Value::Bool(b)).unwrap(),
@@ -614,19 +614,19 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_unary_neg_bool_errors(tc: TestCase) {
+    fn pbt_apply_unary_neg_bool_errors(tc: TestCase) {
         let b = tc.draw(gs::booleans());
         assert!(apply_unary(UnOp::Neg, Value::Bool(b)).is_err());
     }
 
     #[hegel::test]
-    fn apply_unary_not_non_bool_errors(tc: TestCase) {
+    fn pbt_apply_unary_not_non_bool_errors(tc: TestCase) {
         let v = tc.draw(gs::integers::<i64>());
         assert!(apply_unary(UnOp::Not, Value::Int(v)).is_err());
     }
 
     #[hegel::test]
-    fn apply_binary_int_add_is_wrapping(tc: TestCase) {
+    fn pbt_apply_binary_int_add_is_wrapping(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>());
         let y = tc.draw(gs::integers::<i64>());
         let r = apply_binary(BinOp::Add, Value::Int(x), Value::Int(y)).unwrap();
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_int_sub_is_wrapping(tc: TestCase) {
+    fn pbt_apply_binary_int_sub_is_wrapping(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>());
         let y = tc.draw(gs::integers::<i64>());
         let r = apply_binary(BinOp::Sub, Value::Int(x), Value::Int(y)).unwrap();
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_int_mul_is_wrapping(tc: TestCase) {
+    fn pbt_apply_binary_int_mul_is_wrapping(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         let y = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         let r = apply_binary(BinOp::Mul, Value::Int(x), Value::Int(y)).unwrap();
@@ -660,7 +660,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_int_cmp_lt(tc: TestCase) {
+    fn pbt_apply_binary_int_cmp_lt(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         let y = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         let r = apply_binary(BinOp::Lt, Value::Int(x), Value::Int(y)).unwrap();
@@ -668,7 +668,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_bool_and(tc: TestCase) {
+    fn pbt_apply_binary_bool_and(tc: TestCase) {
         let a = tc.draw(gs::booleans());
         let b = tc.draw(gs::booleans());
         let r = apply_binary(BinOp::And, Value::Bool(a), Value::Bool(b)).unwrap();
@@ -676,7 +676,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_bool_or(tc: TestCase) {
+    fn pbt_apply_binary_bool_or(tc: TestCase) {
         let a = tc.draw(gs::booleans());
         let b = tc.draw(gs::booleans());
         let r = apply_binary(BinOp::Or, Value::Bool(a), Value::Bool(b)).unwrap();
@@ -684,20 +684,20 @@ mod tests {
     }
 
     #[hegel::test]
-    fn apply_binary_and_non_bool_errors(tc: TestCase) {
+    fn pbt_apply_binary_and_non_bool_errors(tc: TestCase) {
         let v = tc.draw(gs::integers::<i64>());
         assert!(apply_binary(BinOp::And, Value::Int(v), Value::Bool(true)).is_err());
     }
 
     #[hegel::test]
-    fn apply_binary_eq_int_int(tc: TestCase) {
+    fn pbt_apply_binary_eq_int_int(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>().min_value(-100).max_value(100));
         let r = apply_binary(BinOp::Eq, Value::Int(x), Value::Int(x)).unwrap();
         assert_eq!(r, Value::Bool(true));
     }
 
     #[hegel::test]
-    fn apply_binary_not_eq_distinct_ints(tc: TestCase) {
+    fn pbt_apply_binary_not_eq_distinct_ints(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>().min_value(-100).max_value(100));
         let y = tc.draw(
             gs::integers::<i64>()
@@ -715,14 +715,14 @@ mod tests {
     }
 
     #[hegel::test]
-    fn values_equal_null_anything_is_false(tc: TestCase) {
+    fn pbt_values_equal_null_anything_is_false(tc: TestCase) {
         let v = tc.draw(gs::integers::<i64>());
         assert_eq!(values_equal(&Value::Null, &Value::Int(v)).unwrap(), false);
         assert_eq!(values_equal(&Value::Int(v), &Value::Null).unwrap(), false);
     }
 
     #[hegel::test]
-    fn values_equal_int_float_promotion(tc: TestCase) {
+    fn pbt_values_equal_int_float_promotion(tc: TestCase) {
         let i = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         assert_eq!(
             values_equal(&Value::Int(i), &Value::Float(i as f64)).unwrap(),
@@ -731,7 +731,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn values_equal_str_str(tc: TestCase) {
+    fn pbt_values_equal_str_str(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(32));
         let arc: Arc<str> = Arc::from(s.as_str());
         assert_eq!(
@@ -741,7 +741,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn values_equal_bool_bool(tc: TestCase) {
+    fn pbt_values_equal_bool_bool(tc: TestCase) {
         let b = tc.draw(gs::booleans());
         assert_eq!(
             values_equal(&Value::Bool(b), &Value::Bool(b)).unwrap(),
@@ -759,7 +759,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn as_f64_converts_int_and_float(tc: TestCase) {
+    fn pbt_as_f64_converts_int_and_float(tc: TestCase) {
         let i = tc.draw(
             gs::integers::<i64>()
                 .min_value(-1_000_000)
@@ -772,7 +772,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn agg_sum_ints_matches_wrapping_sum(tc: TestCase) {
+    fn pbt_agg_sum_ints_matches_wrapping_sum(tc: TestCase) {
         let vals =
             tc.draw(gs::vecs(gs::integers::<i64>().min_value(-1000).max_value(1000)).max_size(20));
         let segs: Vec<(i64, Value)> = vals.iter().map(|&v| (1i64, Value::Int(v))).collect();
@@ -791,7 +791,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn agg_avg_equal_durations_is_arithmetic_mean(tc: TestCase) {
+    fn pbt_agg_avg_equal_durations_is_arithmetic_mean(tc: TestCase) {
         let vals = tc.draw(
             gs::vecs(gs::integers::<i64>().min_value(-100).max_value(100))
                 .min_size(2)
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn numeric_min_max_ints(tc: TestCase) {
+    fn pbt_numeric_min_max_ints(tc: TestCase) {
         let x = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         let y = tc.draw(gs::integers::<i64>().min_value(-1000).max_value(1000));
         assert_eq!(
@@ -885,7 +885,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn eval_lens_in_range_vs_out_of_range(tc: TestCase) {
+    fn pbt_eval_lens_in_range_vs_out_of_range(tc: TestCase) {
         let t_in = tc.draw(gs::integers::<i64>().min_value(0).max_value(99));
         let t_out = tc.draw(gs::integers::<i64>().min_value(100).max_value(1_000_000));
         let state = make_int_state("x", &[(0, 100, 7)]);
@@ -966,7 +966,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn at_layers_newest_wins(tc: TestCase) {
+    fn pbt_at_layers_newest_wins(tc: TestCase) {
         let t = tc.draw(gs::integers::<i64>().min_value(0).max_value(9));
         let v1 = tc.draw(gs::integers::<i64>());
         let v2 = tc.draw(gs::integers::<i64>());
@@ -978,7 +978,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn at_layers_returns_none_outside_all_layers(tc: TestCase) {
+    fn pbt_at_layers_returns_none_outside_all_layers(tc: TestCase) {
         let t = tc.draw(gs::integers::<i64>().min_value(100).max_value(1_000_000));
         let layers = vec![Layer::new(1, vec![Tau::new(0, 10, Value::Int(1))])];
         assert_eq!(at_layers(&layers, t), None);

--- a/crates/libtau/src/storage/README.md
+++ b/crates/libtau/src/storage/README.md
@@ -8,23 +8,27 @@ Pluggable backing storage for the layer stack. The `Store<V>` trait is the only 
 pub trait Store<V>: Send + Sync {
     fn append(&mut self, lens: &str, layer: Layer<V>) -> io::Result<bool>;
     fn layers(&self, lens: &str) -> Option<&Vec<Layer<V>>>;
-    fn at(&self, lens: &str, t: Timestamp) -> Option<V>;      // default impl
+    fn at(&self, lens: &str, t: Timestamp) -> Option<V>;       // default impl
     fn drop_lens(&mut self, _lens: &str) {}                    // default no-op
-    fn lens_names(&self) -> Vec<String>;
+    fn lens_names(&self) -> Vec<String> { Vec::new() }         // default empty
+    fn append_schema(&mut self, _stmt: &str) -> io::Result<()> { Ok(()) }  // default no-op
+    fn schema_stmts(&self) -> Vec<String> { Vec::new() }       // default empty
 }
 ```
 
 `append` returns `true` when compaction ran (the caller decides whether to WAL-checkpoint).
 
+`append_schema` / `schema_stmts` let a self-persisting backend (the disk store) keep schema DDL durable. They are no-ops for `InMemory`; WAL-backed setups persist schema in the WAL instead, so `Database` only calls them when no WAL is attached.
+
 ## Implementations
 
 **`InMemory<V>`** — `FxHashMap<String, Vec<Layer<V>>>`. Zero I/O. Used by all unit tests, and the in-memory server mode. Compaction fires automatically when a lens exceeds the threshold.
 
-**`Disk<V>`** — binary flat file with zstd block compression. Header is the 4-byte magic `TAUZ` + VERSION + FLAGS byte + CRC32 (covers magic/version/flags). FLAGS bit 0 signals AES-256-GCM encryption; compressed body is encrypted when set (compress-then-encrypt order). All writes go through `flush()`, which serialises all entries, compresses the payload at the configured level (default 3), optionally encrypts, and atomically replaces the file via a `.tmp` rename. Set `set_rewrite_on_compact(false)` to suppress the rewrite that fires after each compaction. Adjust the compression trade-off with `set_compression_level(level)` (1 = fastest, 22 = best ratio); exposed via `[disk] compression_level` in `config.toml`.
+**`Disk<V>`** — binary flat file (format version 2) with zstd block compression. Header is the 4-byte magic `TAUZ` + VERSION + FLAGS byte + CRC32 (covers magic/version/flags). FLAGS bit 0 signals AES-256-GCM encryption; the compressed body is encrypted when set (compress-then-encrypt order). The body is a schema section (length-prefixed DDL strings) followed by the layer entries. All writes go through `flush()`, which serialises schema + entries, compresses at the configured level (default 3), optionally encrypts, and atomically replaces the file via a `.tmp` rename. A flush fires on **every append** and on every `append_schema`, so both data and DDL (`CREATE LENS` / `DERIVE LENS` / `SET TTL` / `DROP LENS`) are durable before the call returns and survive a restart — the executor replays the schema when `CREATE DATABASE` re-opens the file. Adjust the compression trade-off with `set_compression_level(level)` (1 = fastest, 22 = best ratio); exposed via `[disk] compression_level` in `config.toml`. Version 1 files (no schema section) still open.
 
-> **Note:** the server backend is configurable via `[disk] backend = "disk"` in `config.toml` (default: `"memory"`). 
+> **Note:** the server backend is configurable via `[disk] backend = "disk"` in `config.toml` (default: `"memory"`).
 
-**`Wal`** — write-ahead log. Two entry kinds: data entries (CRC32-prefixed binary) and schema entries (`S:` / `SE:` prefix carrying raw `CREATE LENS` / `DERIVE LENS` text). Schema entries are replayed separately from data on startup. Set `set_fsync_each(false)` and call `sync()` periodically for group-commit mode.
+**`Wal`** — write-ahead log. Two entry kinds: data entries (CRC32-prefixed binary) and schema entries (`S:` / `SE:` prefix carrying raw lens DDL — `CREATE LENS`, `DERIVE LENS`, `SET TTL`, `UNSET TTL`, `DROP LENS`). Schema entries are replayed separately from data on startup. Set `set_fsync_each(false)` and call `sync()` periodically for group-commit mode.
 
 ## Compaction
 

--- a/crates/libtau/src/storage/disk.rs
+++ b/crates/libtau/src/storage/disk.rs
@@ -357,9 +357,10 @@ impl<V: Clone + PartialEq + Codec + Send + Sync + 'static> Store<V> for Disk<V> 
             compact_layers(layers);
             did_compact = layers.len() < before + 1;
         }
-        if did_compact {
-            self.flush()?;
-        }
+        // Persist on every append: the disk backend is the only durability
+        // mechanism when no WAL is attached, so an acknowledged write must hit
+        // disk before we return. (`flush` rewrites the whole file atomically.)
+        self.flush()?;
         Ok(did_compact)
     }
 

--- a/crates/libtau/src/storage/disk.rs
+++ b/crates/libtau/src/storage/disk.rs
@@ -3,11 +3,15 @@
 //! Binary format:
 //!   Header:  MAGIC (4 bytes: "TAUZ") + VERSION (1 byte) + FLAGS (1 byte) +
 //!            CRC32 (4 bytes, covers magic+version+flags)
-//!   Body:    zstd-compressed entries; if FLAGS bit 0 is set, the body is
+//!   Body:    zstd-compressed payload; if FLAGS bit 0 is set, the body is
 //!            AES-256-GCM encrypted before compression (compress-then-encrypt).
-//!   Entries: layer_id (8 bytes, u64) + lens_name_len (4 bytes) + lens_name +
-//!            tau_count (4 bytes) + repeated taus
-//!            Each tau: start (8 bytes, i64) + end (8 bytes, i64) + value (encoded)
+//!   Payload (VERSION >= 2): schema section then entries.
+//!     Schema:  schema_count (4 bytes, u32) + repeated DDL strings
+//!              Each string: len (4 bytes, u32) + UTF-8 bytes
+//!     Entries: layer_id (8 bytes, u64) + lens_name_len (4 bytes) + lens_name +
+//!              tau_count (4 bytes) + repeated taus
+//!              Each tau: start (8 bytes, i64) + end (8 bytes, i64) + value (encoded)
+//!   VERSION 1 files carry no schema section; they still open (schema is empty).
 
 use crate::crypto;
 use crate::model::{Layer, LayerId, Tau};
@@ -21,7 +25,9 @@ use std::path::{Path, PathBuf};
 use crc32fast::Hasher;
 
 const MAGIC: &[u8] = b"TAUZ";
-const VERSION: u8 = 1;
+/// Current on-disk format version. Version 1 had no schema section; version 2
+/// prefixes the entry stream with persisted schema DDL. Both versions open.
+const VERSION: u8 = 2;
 const FLAG_ENCRYPTED: u8 = 0x01;
 const HEADER_LEN: usize = 4 + 1 + 1 + 4; // magic + version + flags + crc32
 /// Default zstd compression level. Valid range is 1–22; higher = better ratio, slower.
@@ -45,6 +51,27 @@ fn read_str<R: Read>(reader: &mut R) -> io::Result<String> {
     let mut buf = vec![0u8; len];
     reader.read_exact(&mut buf)?;
     String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Write the schema section: a `u32` count followed by each length-prefixed string.
+fn write_schema<W: Write>(writer: &mut W, schema: &[String]) -> io::Result<()> {
+    writer.write_all(&(schema.len() as u32).to_le_bytes())?;
+    for stmt in schema {
+        write_str(writer, stmt)?;
+    }
+    Ok(())
+}
+
+/// Read the schema section written by [`write_schema`].
+fn read_schema<R: Read>(reader: &mut R) -> io::Result<Vec<String>> {
+    let mut count_buf = [0u8; 4];
+    reader.read_exact(&mut count_buf)?;
+    let count = u32::from_le_bytes(count_buf) as usize;
+    let mut schema = Vec::with_capacity(count);
+    for _ in 0..count {
+        schema.push(read_str(reader)?);
+    }
+    Ok(schema)
 }
 
 /// Trait for binary encoding/decoding of values.
@@ -142,6 +169,9 @@ impl<V: Codec> DiskEntry<V> {
 pub struct Disk<V> {
     path: PathBuf,
     lenses: HashMap<String, Vec<Layer<V>>>,
+    /// Persisted schema DDL statements in write order. Replayed by the executor
+    /// on restart so `CREATE LENS` / `DERIVE LENS` / `SET TTL` survive.
+    schema: Vec<String>,
     compact_threshold: usize,
     key: Option<[u8; 32]>,
     compression_level: i32,
@@ -152,6 +182,7 @@ impl<V: Clone + Codec> Disk<V> {
     pub fn open(path: impl AsRef<Path>, key: Option<[u8; 32]>) -> io::Result<Self> {
         let path = path.as_ref().to_path_buf();
         let mut lenses: HashMap<String, Vec<Layer<V>>> = HashMap::new();
+        let mut schema: Vec<String> = Vec::new();
 
         if path.exists() {
             let file = File::open(&path)?;
@@ -169,10 +200,11 @@ impl<V: Clone + Codec> Disk<V> {
                     ),
                 ));
             }
-            if header[4] != VERSION {
+            let version = header[4];
+            if version == 0 || version > VERSION {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("unsupported version: expected {VERSION}, got {}", header[4]),
+                    format!("unsupported version: expected 1..={VERSION}, got {version}"),
                 ));
             }
             let flags = header[5];
@@ -204,8 +236,12 @@ impl<V: Clone + Codec> Disk<V> {
                 body
             };
 
-            let entries_bytes = zstd::decode_all(compressed.as_slice())?;
-            let mut cursor = Cursor::new(entries_bytes);
+            let payload_bytes = zstd::decode_all(compressed.as_slice())?;
+            let mut cursor = Cursor::new(payload_bytes);
+            // Version 2+ prefixes the entry stream with the schema section.
+            if version >= 2 {
+                schema = read_schema(&mut cursor)?;
+            }
             loop {
                 match DiskEntry::read(&mut cursor) {
                     Ok(entry) => {
@@ -223,6 +259,7 @@ impl<V: Clone + Codec> Disk<V> {
         Ok(Self {
             path,
             lenses,
+            schema,
             compact_threshold: COMPACT_THRESHOLD,
             key,
             compression_level: DEFAULT_ZSTD_LEVEL,
@@ -238,6 +275,7 @@ impl<V: Clone + Codec> Disk<V> {
         let store = Self {
             path,
             lenses: HashMap::new(),
+            schema: Vec::new(),
             compact_threshold: COMPACT_THRESHOLD,
             key,
             compression_level: DEFAULT_ZSTD_LEVEL,
@@ -260,6 +298,7 @@ impl<V: Clone + Codec> Disk<V> {
     /// Flush all in-memory state to disk atomically (compress → optionally encrypt → write).
     pub fn flush(&self) -> io::Result<()> {
         let mut entries = Vec::new();
+        write_schema(&mut entries, &self.schema)?;
         for (lens_name, layers) in &self.lenses {
             for layer in layers {
                 let entry = DiskEntry {
@@ -334,6 +373,16 @@ impl<V: Clone + PartialEq + Codec + Send + Sync + 'static> Store<V> for Disk<V> 
 
     fn lens_names(&self) -> Vec<String> {
         self.lenses.keys().cloned().collect()
+    }
+
+    fn append_schema(&mut self, stmt: &str) -> io::Result<()> {
+        self.schema.push(stmt.to_string());
+        // Persist immediately so DDL survives an unclean shutdown.
+        self.flush()
+    }
+
+    fn schema_stmts(&self) -> Vec<String> {
+        self.schema.clone()
     }
 }
 

--- a/crates/libtau/src/storage/disk.rs
+++ b/crates/libtau/src/storage/disk.rs
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn create_append_at_matches_in_memory(tc: TestCase) {
+    fn pbt_create_append_at_matches_in_memory(tc: TestCase) {
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-10).max_value(2000));
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn open_after_flush_replays_data_unencrypted(tc: TestCase) {
+    fn pbt_open_after_flush_replays_data_unencrypted(tc: TestCase) {
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-10).max_value(2000));
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn open_after_flush_replays_data_encrypted(tc: TestCase) {
+    fn pbt_open_after_flush_replays_data_encrypted(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn encrypted_file_rejects_open_without_key(tc: TestCase) {
+    fn pbt_encrypted_file_rejects_open_without_key(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn encrypted_file_rejects_open_with_wrong_key(tc: TestCase) {
+    fn pbt_encrypted_file_rejects_open_with_wrong_key(tc: TestCase) {
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
@@ -527,7 +527,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn invalid_magic_rejected(tc: TestCase) {
+    fn pbt_invalid_magic_rejected(tc: TestCase) {
         let bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(4).max_size(64));
         if &bytes[..4] == b"TAUZ" {
             return; // skip valid prefix
@@ -539,7 +539,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn custom_compression_level_round_trips(tc: TestCase) {
+    fn pbt_custom_compression_level_round_trips(tc: TestCase) {
         let level = tc.draw(gs::integers::<i32>().min_value(1).max_value(22));
         let lens = tc.draw(lens_name_gen());
         let layer = Layer::new(1, tc.draw(taus_gen()));
@@ -577,7 +577,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn multiple_lenses_round_trip(tc: TestCase) {
+    fn pbt_multiple_lenses_round_trip(tc: TestCase) {
         let entries: Vec<(String, Layer<i32>)> = (0..3)
             .map(|i| {
                 let mut name = tc.draw(lens_name_gen());

--- a/crates/libtau/src/storage/memory.rs
+++ b/crates/libtau/src/storage/memory.rs
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn empty_store_returns_none_for_any_lens(tc: TestCase) {
+    fn pbt_empty_store_returns_none_for_any_lens(tc: TestCase) {
         let lens = tc.draw(gs::text().max_size(16));
         let t = tc.draw(gs::integers::<i64>());
         let store: InMemory<i32> = InMemory::new();
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn append_then_at_matches_layer_lookup(tc: TestCase) {
+    fn pbt_append_then_at_matches_layer_lookup(tc: TestCase) {
         let taus = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-5).max_value(500));
         let mut store: InMemory<i8> = InMemory::with_threshold(1024);
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn newest_layer_wins(tc: TestCase) {
+    fn pbt_newest_layer_wins(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen());
         let probe = tc.draw(gs::integers::<i64>().min_value(-10).max_value(500));
         let mut store: InMemory<i8> = InMemory::with_threshold(1024);
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_preserves_point_lookups(tc: TestCase) {
+    fn pbt_compaction_preserves_point_lookups(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen());
         let probe = tc.draw(gs::integers::<i64>().min_value(-10).max_value(500));
 
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_never_grows_layer_count(tc: TestCase) {
+    fn pbt_compaction_never_grows_layer_count(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen());
         let before_len = stack.len();
         let mut compacted = stack;
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_yields_at_most_one_layer(tc: TestCase) {
+    fn pbt_compaction_yields_at_most_one_layer(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen().filter(|v| !v.is_empty()));
         let mut compacted = stack;
         compact_layers(&mut compacted);
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_layer_has_non_overlapping_taus(tc: TestCase) {
+    fn pbt_compaction_layer_has_non_overlapping_taus(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen());
         let mut compacted = stack;
         compact_layers(&mut compacted);
@@ -202,7 +202,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_merges_adjacent_equal_values(tc: TestCase) {
+    fn pbt_compaction_merges_adjacent_equal_values(tc: TestCase) {
         let stack = tc.draw(layer_stack_gen().filter(|v| v.len() >= 2));
         let mut compacted = stack;
         compact_layers(&mut compacted);
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn compaction_triggers_above_threshold(tc: TestCase) {
+    fn pbt_compaction_triggers_above_threshold(tc: TestCase) {
         // For any threshold k and any (k+1) single-tau layers, the store
         // ends with at most one layer (compaction always runs).
         let k = tc.draw(gs::integers::<usize>().min_value(1).max_value(16));
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn lenses_are_independent(tc: TestCase) {
+    fn pbt_lenses_are_independent(tc: TestCase) {
         let a_taus = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let b_taus = tc.draw(taus_gen().filter(|v| !v.is_empty()));
         let probe = tc.draw(gs::integers::<i64>().min_value(-5).max_value(500));
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn append_returns_did_compact_consistent_with_layer_count(tc: TestCase) {
+    fn pbt_append_returns_did_compact_consistent_with_layer_count(tc: TestCase) {
         // append() returns true iff post-append len < prior+1, i.e. compaction
         // shortened the stack.
         let k = tc.draw(gs::integers::<usize>().min_value(1).max_value(8));

--- a/crates/libtau/src/storage/store.rs
+++ b/crates/libtau/src/storage/store.rs
@@ -44,4 +44,20 @@ where
     fn lens_names(&self) -> Vec<String> {
         Vec::new()
     }
+
+    /// Durably record a schema DDL statement (e.g. `CREATE LENS temp int`) so
+    /// it can be replayed on restart.
+    ///
+    /// Only backends that own their own on-disk file need this; for
+    /// WAL-backed setups schema persistence lives in the WAL and this is never
+    /// called.  The default is a no-op (in-memory stores keep no schema).
+    fn append_schema(&mut self, _stmt: &str) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Return the persisted schema DDL statements in write order.  Default is
+    /// empty; backends that persist schema override this.
+    fn schema_stmts(&self) -> Vec<String> {
+        Vec::new()
+    }
 }

--- a/crates/libtau/src/storage/wal.rs
+++ b/crates/libtau/src/storage/wal.rs
@@ -667,7 +667,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn entry_serialise_deserialise_roundtrips_i64(tc: TestCase) {
+    fn pbt_entry_serialise_deserialise_roundtrips_i64(tc: TestCase) {
         let entry = tc.draw(entry_gen_i64());
         let line = entry.serialise();
         let decoded = WalEntry::<i64>::deserialise(&line).expect("decode own serialisation");
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn entry_serialise_starts_with_checksum_digits(tc: TestCase) {
+    fn pbt_entry_serialise_starts_with_checksum_digits(tc: TestCase) {
         let entry = tc.draw(entry_gen_i64());
         let line = entry.serialise();
         assert!(
@@ -685,7 +685,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn entry_deserialise_never_panics_on_arbitrary_text(tc: TestCase) {
+    fn pbt_entry_deserialise_never_panics_on_arbitrary_text(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(256));
         // Both i64 and bool decoders must tolerate any text without panicking.
         let _ = WalEntry::<i64>::deserialise(&s);
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn entry_deserialise_rejects_checksum_corruption(tc: TestCase) {
+    fn pbt_entry_deserialise_rejects_checksum_corruption(tc: TestCase) {
         let entry = tc.draw(entry_gen_i64());
         let line = entry.serialise();
         // Pick a non-zero corruption to bump the leading digit.  Any single
@@ -710,20 +710,20 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_i64_roundtrips_every_value(tc: TestCase) {
+    fn pbt_codec_i64_roundtrips_every_value(tc: TestCase) {
         let v = tc.draw(gs::integers::<i64>());
         assert_eq!(i64::decode(&v.encode()), Some(v));
     }
 
     #[hegel::test]
-    fn codec_f64_roundtrips_finite_values(tc: TestCase) {
+    fn pbt_codec_f64_roundtrips_finite_values(tc: TestCase) {
         let v = tc.draw(gs::floats::<f64>().filter(|f| f.is_finite()));
         let decoded = f64::decode(&v.encode()).unwrap();
         assert!((decoded - v).abs() <= f64::EPSILON * v.abs().max(1.0));
     }
 
     #[hegel::test]
-    fn codec_bool_roundtrips(tc: TestCase) {
+    fn pbt_codec_bool_roundtrips(tc: TestCase) {
         let v = tc.draw(gs::booleans());
         assert_eq!(bool::decode(&v.encode()), Some(v));
     }
@@ -735,17 +735,17 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_i64_encode_into_matches_encode(tc: TestCase) {
+    fn pbt_codec_i64_encode_into_matches_encode(tc: TestCase) {
         check_encode_into(&tc.draw(gs::integers::<i64>()));
     }
 
     #[hegel::test]
-    fn codec_f64_encode_into_matches_encode(tc: TestCase) {
+    fn pbt_codec_f64_encode_into_matches_encode(tc: TestCase) {
         check_encode_into(&tc.draw(gs::floats::<f64>().filter(|f| f.is_finite())));
     }
 
     #[hegel::test]
-    fn codec_bool_encode_into_matches_encode(tc: TestCase) {
+    fn pbt_codec_bool_encode_into_matches_encode(tc: TestCase) {
         check_encode_into(&tc.draw(gs::booleans()));
     }
 
@@ -766,7 +766,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_i64_decode_returns_none_on_unparseable(tc: TestCase) {
+    fn pbt_codec_i64_decode_returns_none_on_unparseable(tc: TestCase) {
         let s = tc
             .draw(gs::text().max_size(32))
             .replace(|c: char| c.is_ascii_digit() || c == '-', "x");
@@ -820,12 +820,12 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_unencrypted_replay_matches_inmemory(tc: TestCase) {
+    fn pbt_wal_unencrypted_replay_matches_inmemory(tc: TestCase) {
         wal_replay_matches_inmemory(tc, None);
     }
 
     #[hegel::test]
-    fn wal_encrypted_replay_matches_inmemory(tc: TestCase) {
+    fn pbt_wal_encrypted_replay_matches_inmemory(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let mut key = [0u8; 32];
         key.copy_from_slice(&key_bytes);
@@ -833,7 +833,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_encrypted_lines_start_with_e_prefix(tc: TestCase) {
+    fn pbt_wal_encrypted_lines_start_with_e_prefix(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let entry = tc.draw(entry_gen_i64().filter(|e| !e.taus.is_empty()));
         let mut key = [0u8; 32];
@@ -849,7 +849,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_encrypted_replay_without_key_skips_entries(tc: TestCase) {
+    fn pbt_wal_encrypted_replay_without_key_skips_entries(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let entry = tc.draw(entry_gen_i64().filter(|e| !e.taus.is_empty()));
         let mut key = [0u8; 32];
@@ -890,7 +890,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_skips_corrupted_entries_during_replay(tc: TestCase) {
+    fn pbt_wal_skips_corrupted_entries_during_replay(tc: TestCase) {
         let good_a = tc.draw(entry_gen_i64().filter(|e| !e.taus.is_empty()));
         let good_b = tc.draw(entry_gen_i64().filter(|e| !e.taus.is_empty()));
         let tmp = NamedTempFile::new().unwrap();
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_schema_roundtrips_unencrypted(tc: TestCase) {
+    fn pbt_wal_schema_roundtrips_unencrypted(tc: TestCase) {
         let stmts = tc.draw(
             gs::vecs(
                 gs::from_regex(r"CREATE LENS [a-z]+ (int|float|str|bool|bytes)").fullmatch(true),
@@ -950,7 +950,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_schema_roundtrips_encrypted(tc: TestCase) {
+    fn pbt_wal_schema_roundtrips_encrypted(tc: TestCase) {
         let key_bytes = tc.draw(gs::vecs(gs::integers::<u8>()).min_size(32).max_size(32));
         let stmts = tc.draw(
             gs::vecs(
@@ -977,7 +977,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_rotate_creates_archive_with_pre_rotation_layers(tc: TestCase) {
+    fn pbt_wal_rotate_creates_archive_with_pre_rotation_layers(tc: TestCase) {
         let initial: Vec<WalEntry<i64>> = (0..tc
             .draw(gs::integers::<usize>().min_value(1).max_value(4)))
             .map(|_| tc.draw(entry_gen_i64().filter(|e| !e.taus.is_empty())))
@@ -1044,7 +1044,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn wal_rotate_retains_only_supplied_entries(tc: TestCase) {
+    fn pbt_wal_rotate_retains_only_supplied_entries(tc: TestCase) {
         let schemas = tc
             .draw(gs::vecs(gs::from_regex(r"CREATE LENS [a-z]+ int").fullmatch(true)).max_size(3));
         let initial: Vec<WalEntry<i64>> = (0..tc

--- a/crates/libtau/src/users.rs
+++ b/crates/libtau/src/users.rs
@@ -380,14 +380,14 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_display_parse_roundtrip(tc: TestCase) {
+    fn pbt_perm_display_parse_roundtrip(tc: TestCase) {
         let p = tc.draw(perm_gen());
         let s = p.to_string();
         assert_eq!(Perm::parse(&s).unwrap(), p);
     }
 
     #[hegel::test]
-    fn perm_parse_letter_order_is_irrelevant(tc: TestCase) {
+    fn pbt_perm_parse_letter_order_is_irrelevant(tc: TestCase) {
         // Any permutation of a subset of CRUDA parses to the same Perm.
         let p = tc.draw(perm_gen());
         let s = p.to_string();
@@ -404,7 +404,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_parse_case_insensitive(tc: TestCase) {
+    fn pbt_perm_parse_case_insensitive(tc: TestCase) {
         let p = tc.draw(perm_gen());
         let upper = p.to_string();
         let lower = upper.to_lowercase();
@@ -419,7 +419,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_parse_rejects_unknown_letter(tc: TestCase) {
+    fn pbt_perm_parse_rejects_unknown_letter(tc: TestCase) {
         let bad = tc.draw(
             gs::characters().filter(|c| !"CRUDAcruda \t".contains(*c) && *c != '*' && *c != '-'),
         );
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_bitops_are_commutative_and_associative(tc: TestCase) {
+    fn pbt_perm_bitops_are_commutative_and_associative(tc: TestCase) {
         let a = tc.draw(perm_gen());
         let b = tc.draw(perm_gen());
         let c = tc.draw(perm_gen());
@@ -440,7 +440,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_contains_iff_bits_are_subset(tc: TestCase) {
+    fn pbt_perm_contains_iff_bits_are_subset(tc: TestCase) {
         let p = tc.draw(perm_gen());
         let q = tc.draw(perm_gen());
         let expected = (p.bits() & q.bits()) == q.bits();
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn perm_insert_remove_inverse(tc: TestCase) {
+    fn pbt_perm_insert_remove_inverse(tc: TestCase) {
         let mut p = tc.draw(perm_gen());
         let q = tc.draw(perm_gen());
         let original = p;
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn user_verify_accepts_correct_password_only(tc: TestCase) {
+    fn pbt_user_verify_accepts_correct_password_only(tc: TestCase) {
         let name = tc.draw(name_gen());
         let pw = tc.draw(gs::text().min_size(1).max_size(32));
         let other = tc.draw(gs::text().min_size(1).max_size(32).filter({
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn user_effective_equals_direct_union_wildcard(tc: TestCase) {
+    fn pbt_user_effective_equals_direct_union_wildcard(tc: TestCase) {
         let grants = tc.draw(grants_gen());
         let db = tc.draw(name_gen());
         let u = User::new("u", "p", grants.clone()); // codeql[rust/hard-coded-cryptographic-value]
@@ -486,7 +486,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn user_is_global_admin_iff_admin_on_wildcard(tc: TestCase) {
+    fn pbt_user_is_global_admin_iff_admin_on_wildcard(tc: TestCase) {
         let grants = tc.draw(grants_gen());
         let u = User::new("u", "p", grants.clone()); // codeql[rust/hard-coded-cryptographic-value]
         let expected = grants
@@ -497,7 +497,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn user_to_from_line_roundtrip(tc: TestCase) {
+    fn pbt_user_to_from_line_roundtrip(tc: TestCase) {
         let name = tc.draw(name_gen());
         let pw = tc.draw(gs::text().min_size(1).max_size(32));
         let grants = tc.draw(grants_gen());
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn store_add_then_get_returns_user(tc: TestCase) {
+    fn pbt_store_add_then_get_returns_user(tc: TestCase) {
         let name = tc.draw(name_gen());
         let mut s = UserStore::new();
         s.add(User::new(&name, "p", HashMap::new())).unwrap(); // codeql[rust/hard-coded-cryptographic-value]
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn store_remove_then_get_returns_none(tc: TestCase) {
+    fn pbt_store_remove_then_get_returns_none(tc: TestCase) {
         let name = tc.draw(name_gen());
         let mut s = UserStore::new();
         s.add(User::new(&name, "p", HashMap::new())).unwrap(); // codeql[rust/hard-coded-cryptographic-value]
@@ -530,7 +530,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn store_grant_then_revoke_is_identity_on_perms(tc: TestCase) {
+    fn pbt_store_grant_then_revoke_is_identity_on_perms(tc: TestCase) {
         let name = tc.draw(name_gen());
         let db = tc.draw(name_gen());
         let to_add = tc.draw(perm_gen());
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn store_grant_unions_into_existing_perms(tc: TestCase) {
+    fn pbt_store_grant_unions_into_existing_perms(tc: TestCase) {
         let name = tc.draw(name_gen());
         let db = tc.draw(name_gen());
         let p1 = tc.draw(perm_gen());
@@ -558,7 +558,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn store_persists_round_trip(tc: TestCase) {
+    fn pbt_store_persists_round_trip(tc: TestCase) {
         let n = tc.draw(gs::integers::<usize>().min_value(0).max_value(5));
         let dir = tempdir().unwrap();
         let path = dir.path().join("u");

--- a/crates/libtau/src/value.rs
+++ b/crates/libtau/src/value.rs
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn type_name_matches_variant(tc: TestCase) {
+    fn pbt_type_name_matches_variant(tc: TestCase) {
         let v = tc.draw(value_gen());
         let expected = match &v {
             Value::Int(_) => "int",
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn ty_returns_type_for_non_null(tc: TestCase) {
+    fn pbt_ty_returns_type_for_non_null(tc: TestCase) {
         let v = tc.draw(value_gen());
         match (&v, v.ty()) {
             (Value::Int(_), Some(Type::Int)) => {}
@@ -294,7 +294,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn from_literal_owned_and_ref_agree(tc: TestCase) {
+    fn pbt_from_literal_owned_and_ref_agree(tc: TestCase) {
         let v = tc.draw(value_gen());
         let lit: Literal = match v.clone() {
             Value::Int(i) => Literal::Int(i),
@@ -310,7 +310,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_roundtrips_every_value(tc: TestCase) {
+    fn pbt_codec_roundtrips_every_value(tc: TestCase) {
         let v = tc.draw(value_gen());
         // Float NaN is filtered out by the generator; for everything else
         // PartialEq must hold across encode + decode.
@@ -320,7 +320,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_encode_into_matches_encode(tc: TestCase) {
+    fn pbt_codec_encode_into_matches_encode(tc: TestCase) {
         let v = tc.draw(value_gen());
         let mut buf = String::new();
         v.encode_into(&mut buf);
@@ -328,7 +328,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_str_encoding_never_contains_separators(tc: TestCase) {
+    fn pbt_codec_str_encoding_never_contains_separators(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(128));
         let v = Value::Str(Arc::from(s.as_str()));
         let enc = v.encode();
@@ -345,13 +345,13 @@ mod tests {
     }
 
     #[hegel::test]
-    fn codec_decode_never_panics_on_arbitrary_input(tc: TestCase) {
+    fn pbt_codec_decode_never_panics_on_arbitrary_input(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(128));
         let _ = Value::decode(&s);
     }
 
     #[hegel::test]
-    fn codec_rejects_unknown_or_malformed_tags(tc: TestCase) {
+    fn pbt_codec_rejects_unknown_or_malformed_tags(tc: TestCase) {
         // Any first byte outside the known tag set must yield None.
         let known: [char; 5] = ['i', 'f', 's', 'b', 'n'];
         let tag = tc.draw(gs::characters().filter(move |c| !known.contains(c)));

--- a/crates/libtau/src/wire.rs
+++ b/crates/libtau/src/wire.rs
@@ -425,7 +425,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_never_panics_on_arbitrary_text(tc: TestCase) {
+    fn pbt_parse_never_panics_on_arbitrary_text(tc: TestCase) {
         let s = tc.draw(gs::text().max_size(512));
         let _ = Response::parse(&s);
     }
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_roundtrips_val(tc: TestCase) {
+    fn pbt_parse_roundtrips_val(tc: TestCase) {
         let v = tc.draw(value_gen());
         let r = Response::Val(Some(v));
         let line = r.to_string();
@@ -457,7 +457,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_roundtrips_range(tc: TestCase) {
+    fn pbt_parse_roundtrips_range(tc: TestCase) {
         let segs: Vec<(i64, i64, Value)> = tc
             .draw(
                 gs::vecs(
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_roundtrips_names(tc: TestCase) {
+    fn pbt_parse_roundtrips_names(tc: TestCase) {
         let names: Vec<String> =
             tc.draw(gs::vecs(gs::from_regex(r"[a-z][a-z0-9_]{0,8}").fullmatch(true)).max_size(8));
         let r = Response::Names(names);

--- a/crates/libtau/src/wire.rs
+++ b/crates/libtau/src/wire.rs
@@ -257,7 +257,9 @@ impl fmt::Display for Response {
     }
 }
 
-/// Render an [`ExecError`] to its wire message (without the `ERR ` prefix).
+/// Reconstruct an [`ExecError`] from its wire message (the text after `ERR `).
+/// The inverse of [`encode_error`]; only the structured variants the client
+/// branches on are recovered, everything else collapses to [`ExecError::InvalidExpr`].
 fn decode_exec_error(msg: &str) -> ExecError {
     if let Some(name) = msg.strip_prefix("unknown lens: ") {
         return ExecError::UnknownLens(name.into());

--- a/crates/tau/README.md
+++ b/crates/tau/README.md
@@ -33,6 +33,11 @@ bind = "127.0.0.1:7070"
 log_level = "info"
 compact_threshold = 8
 
+[disk]
+backend = "memory"          # "memory" (default) or "disk"
+# path = "/var/lib/tau/data"  # required for backend = "disk"; one <db>.dat per database
+compression_level = 3       # zstd level 1–22 (disk backend)
+
 [wal]
 enabled = true
 path = "/var/lib/tau/tau.wal"

--- a/crates/tau/src/config.rs
+++ b/crates/tau/src/config.rs
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[hegel::test(test_cases = 1000)]
-    fn property_toml_round_trip(tc: TestCase) {
+    fn pbt_property_toml_round_trip(tc: TestCase) {
         let original_config = tc.draw(config_generator());
         let toml_string = toml::to_string(&original_config)
             .expect("Valid structural Config setups must serialize smoothly");

--- a/crates/tau/src/handler.rs
+++ b/crates/tau/src/handler.rs
@@ -201,14 +201,14 @@ mod tests {
     }
 
     #[hegel::test]
-    fn handle_query_never_panics(tc: TestCase) {
+    fn pbt_handle_query_never_panics(tc: TestCase) {
         let input = tc.draw(gs::text().max_size(256));
         let e = exec();
         let _ = q(&input, &e, None);
     }
 
     #[hegel::test]
-    fn at_after_append_returns_encoded_value(tc: TestCase) {
+    fn pbt_at_after_append_returns_encoded_value(tc: TestCase) {
         let v = tc.draw(
             gs::integers::<i64>()
                 .min_value(-1_000_000)
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn at_uncovered_timestamp_yields_nil(tc: TestCase) {
+    fn pbt_at_uncovered_timestamp_yields_nil(tc: TestCase) {
         let probe = tc.draw(gs::integers::<i64>().min_value(101).max_value(1_000_000));
         let e = exec();
         q("CREATE DATABASE main", &e, None);
@@ -236,7 +236,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_failure_starts_with_err_parse(tc: TestCase) {
+    fn pbt_parse_failure_starts_with_err_parse(tc: TestCase) {
         let junk = tc.draw(gs::from_regex("[A-Z]{4,12}").fullmatch(true).filter(|s| {
             !matches!(
                 s.as_str(),
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn trailing_input_is_reported(tc: TestCase) {
+    fn pbt_trailing_input_is_reported(tc: TestCase) {
         let extra = tc.draw(gs::from_regex("[A-Z][A-Z]+").fullmatch(true));
         let r = q(&format!("CREATE DATABASE a {extra}"), &exec(), None);
         assert!(r.starts_with("ERR trailing input"), "got: {r}");
@@ -342,7 +342,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn parse_auth_line_roundtrips_for_valid_input(tc: TestCase) {
+    fn pbt_parse_auth_line_roundtrips_for_valid_input(tc: TestCase) {
         let user = tc.draw(gs::from_regex("[a-z][a-z0-9_]{0,10}").fullmatch(true));
         let pass = tc.draw(gs::from_regex("[A-Za-z0-9!@#$%^&*]{1,16}").fullmatch(true));
         let line = format!("AUTH {user} {pass}");

--- a/crates/tauctl/src/tui/mod.rs
+++ b/crates/tauctl/src/tui/mod.rs
@@ -1,6 +1,6 @@
 //! ratatui TUI for tauctl.
 //!
-//! Runs when stdout is a TTY (default). For scripts and pipes use `--headless`.
+//! Requires an interactive terminal; `main` exits early when stdout is not a TTY.
 //!
 //! Layout:
 //!   ┌─ Connections ─┬─ Results ──────────────────┐

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -34,6 +34,8 @@ log_level = "info"         # error | warn | info | debug | trace
 compact_threshold = 8      # layers per lens before auto-compaction fires
 
 [disk]
+backend = "memory"         # "memory" (default) or "disk" (persist to <path>/<db>.dat)
+# path = "/var/lib/tau/data"  # required when backend = "disk"
 compression_level = 3      # zstd level 1–22; higher = better ratio, slower writes
 
 [wal]
@@ -78,7 +80,17 @@ idle_timeout_secs = 300     # 0 disables
 
 | field | default | description |
 |-------|---------|-------------|
+| `backend` | `memory` | Storage backend. `memory` keeps layers in RAM (pair with `[wal]` for durability). `disk` gives every database its own compressed `<path>/<name>.dat` file. |
+| `path` | (none) | Directory for the per-database `.dat` files — required when `backend = "disk"`. |
 | `compression_level` | `3` | zstd compression level applied when the disk store flushes. Range 1–22: 1 is fastest with least compression, 22 is best ratio but slowest. |
+
+With `backend = "disk"`, each `.dat` file persists both layer data and the
+schema DDL (`CREATE LENS`, `DERIVE LENS`, `SET TTL`, `DROP LENS`). Issuing
+`CREATE DATABASE <name>` re-opens an existing `<name>.dat` and replays its
+schema, so lenses and policies survive a restart without re-issuing DDL. The
+disk store rewrites its file atomically on every append and every schema
+change, so an acknowledged write is durable before the response returns; the
+`[wal]` settings are ignored when this backend is active.
 
 ---
 

--- a/docs/content/docs/dst.md
+++ b/docs/content/docs/dst.md
@@ -86,12 +86,14 @@ Each profile in a run is driven with the same `--seed` (re-seeded per profile fo
 | Memory | Rebuild target + oracle, dual-replay op log |
 | WAL (odd) | Delete WAL + oracle replay; dual-replay op log |
 | WAL (even) | Truncate WAL at random offset; fresh target; reset op log |
-| Disk | Wipe target `.dat` trees, dual-replay op log |
+| Disk | Wipe target `.dat` files, dual-replay op log (tests replay equivalence). A separate `pbt_disk_persists_*_across_reopen` test exercises faithful restart over the real persisted files (no wipe) after per-append flushes. |
 | Wire | Memory-style replay (no WAL/disk files) |
 
 **Transactions** are enabled for memory/disk/wire profiles. WAL profiles use `WAL_EXCLUDED` tags in the behavior tree to skip transaction and multi-DB ops until single-DB WAL replay semantics are fully validated.
 
 For TTL, DST pins the wall clock via [`wall_clock::set_fixed_now_secs`](https://github.com/bxrne/tau/tree/master/crates/libtau/src/wall_clock.rs) (`1_700_000_000`).
+
+The `disk` backend (when selected) now flushes its `<db>.dat` atomically on *every* append and every schema DDL (`CREATE`/`DERIVE`/`SET TTL`/`DROP`). This makes acknowledged DML and lens definitions durable across clean restarts without a WAL; `CREATE DATABASE <name>` on a disk executor re-opens the `.dat` and replays its embedded schema section to restore base/derived lenses and TTL policies. The new `pbt_disk_persists_data_and_schema_across_reopen` test in `sim.rs` covers this path under the DST harness.
 
 ## Concurrent phase
 
@@ -114,5 +116,7 @@ Then the Docker image build.
 cargo nextest run --release -p libdst   # framework: btree, divergence, scheduler, shrink, ...
 cargo nextest run --release -p dst      # driver: oracle, apply, btree, sim profiles
 ```
+
+All `#[hegel::test]` property-based tests across crates are named with a `pbt_` prefix (e.g. `pbt_...`) so they are easy to filter in logs and CI output.
 
 See [Testing](/docs/testing/) for the full strategy.

--- a/docs/content/docs/how-it-works.md
+++ b/docs/content/docs/how-it-works.md
@@ -28,7 +28,7 @@ The cost is that every query must resolve which layer wins at each point in time
 
 ## Architecture
 
-Tau is structured as a library (`libtau`) consumed by two binaries: the TCP server (`tau`) and the interactive client (`tauctl`, a ratatui TUI with a `--headless` fallback). The library exposes a clean `Executor` API; auth, TLS, and network concerns live exclusively in the server.
+Tau is structured as a library (`libtau`) consumed by two binaries: the TCP server (`tau`) and the interactive client (`tauctl`, a ratatui TUI that requires an interactive terminal). The library exposes a clean `Executor` API; auth, TLS, and network concerns live exclusively in the server.
 
 ```
 Stmt → Executor → Database<Value> → Store<V> + optional Wal
@@ -87,19 +87,24 @@ Cycle detection runs at `DERIVE` time by walking the dependency graph (`would_cy
 
 **`InMemory`**: a `HashMap<name, Vec<Layer<V>>>` with no I/O. Used for tests and ephemeral workloads.
 
-**`Disk`**: a binary file:
+**`Disk`**: one compressed binary file per database (`<name>.dat`):
 
 ```
-magic (3 bytes)  "TAU" (plaintext) or "TAUE" (encrypted)
-[entries...]
-  length (u32 LE)
-  crc32 (u32 LE) or nonce+tag (encrypted)
-  payload bytes
+header
+  magic   "TAUZ" (4 bytes)
+  version u8         # 2; version 1 (no schema section) still opens
+  flags   u8         # bit 0 = encrypted body
+  crc32   u32 LE     # over magic+version+flags
+body  zstd-compressed payload, AES-256-GCM-encrypted after compression when flagged
+  payload
+    schema_count u32 LE        # persisted DDL statements
+    [ len u32 LE, utf8 bytes ] # CREATE LENS / DERIVE LENS / SET TTL / DROP LENS
+    [ DiskEntry... ]           # layer_id, lens name, taus — until EOF
 ```
 
-On open, the file is read entry by entry, integrity-checked, and replayed into the in-memory layer stack. The file handle stays open in append mode.
+On open, the header is integrity-checked, the body decompressed (and decrypted when flagged), the schema section read, then layer entries replayed into the in-memory layer stack. The file is rewritten atomically (`.tmp` + rename) on each flush — a flush fires on every append and every schema change, so an acknowledged write is durable before the call returns. Because schema DDL is part of the file, `CREATE DATABASE <name>` re-opens an existing `<name>.dat` and replays its schema, so lenses and TTL policies survive a restart.
 
-Encryption is AES-256-GCM with a random 12-byte nonce per entry. The key is never stored; it must be supplied via `TAU_ENCRYPTION_KEY` at startup. The `TAUE` magic prevents accidentally opening an encrypted file without a key.
+Encryption is AES-256-GCM with a random 12-byte nonce. The key is never stored; it must be supplied via `TAU_ENCRYPTION_KEY` at startup. The `FLAG_ENCRYPTED` bit prevents accidentally opening an encrypted file without a key.
 
 ### Write-Ahead Log
 
@@ -113,7 +118,7 @@ S:<checksum> <CREATE LENS ...>     # schema DDL
 SE:<crc32hex> <base64-encrypted>   # encrypted schema DDL
 ```
 
-Schema entries carry the raw TauQL text of `CREATE LENS` and `DERIVE LENS`. On replay, these are re-parsed and executed with `in_replay = true`, which suppresses re-appending them to the WAL.
+Schema entries carry the raw TauQL text of the DDL that defines a lens (`CREATE LENS`, `DERIVE LENS`, `SET TTL`, `UNSET TTL`, `DROP LENS`). On replay, these are re-parsed and executed with `in_replay = true`, which suppresses re-appending them to the WAL. The disk backend persists the same DDL set in its own file (see above).
 
 The WAL is checkpointed after compaction: a fresh snapshot of in-memory state is written to a new file and swapped in, bounding disk usage.
 

--- a/docs/content/docs/testing.md
+++ b/docs/content/docs/testing.md
@@ -63,7 +63,7 @@ cargo test --release                               # fallback if nextest is not 
 cargo nextest run --release   # Hegel runs inline alongside example tests
 ```
 
-Hegel auto-installs a Python shim (`~/.cache/hegel`) on first run. Each property runs 100+ randomised cases by default. Use `HEGEL_MAX_EXAMPLES=500` to increase the draw count.
+All such tests are named `pbt_*` for easy log filtering. Hegel auto-installs a Python shim (`~/.cache/hegel`) on first run. Each property runs 100+ randomised cases by default. Use `HEGEL_MAX_EXAMPLES=500` to increase the draw count.
 
 ---
 


### PR DESCRIPTION
Updated documentation (implementation and outdated), added proper disk persistence for all ddls now (disk prev relied on wal). dst testing for this and dml. more pbt tests too (and a rename). 